### PR TITLE
Object mapper abstraction support.

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -1,6 +1,7 @@
 require 'action_view'
 require 'simple_form/action_view_extensions/form_helper'
 require 'simple_form/action_view_extensions/builder'
+require 'simple_form/oms'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/reverse_merge'
@@ -10,6 +11,8 @@ module SimpleForm
 
   autoload :Helpers
   autoload :Wrappers
+  autoload :Column
+  autoload :Association
 
   eager_autoload do
     autoload :Components

--- a/lib/simple_form/association.rb
+++ b/lib/simple_form/association.rb
@@ -1,0 +1,27 @@
+# An Association object represents the specs of an relationship as
+# defined by the Object Mapper in an Object Mapper independent mannor.
+# A Object Mapper independent version of
+# ActiveRecord::Associations::Association
+class SimpleForm::Association
+
+  # Should be :belongs_to, :has_one or :has_many
+  attr_accessor :macro
+
+  # The type of object this association relates to
+  attr_accessor :klass
+
+  # The name of this association
+  attr_accessor :name
+
+  # Configuration options for the assocation. The options that SimpleForm
+  # actually uses are. :foreign_key, :conditions and :order. They are
+  # all optional.
+  attr_reader :options
+
+  # Creates a new assocation. Takes a block to assign the attributes
+  def initialize
+    @options = {}
+    yield self if block_given?
+  end
+
+end

--- a/lib/simple_form/column.rb
+++ b/lib/simple_form/column.rb
@@ -1,0 +1,24 @@
+# A Column object respresents the specs of an attribute as defined in
+# the database in an Object Mapper independent manor. A Object Mapper
+# independent version of ActiveRecord::ConnectionAdapters::ColumnDefinition
+class SimpleForm::Column
+
+  # The type of data stored in this column. This is a symbol.
+  attr_accessor :type
+
+  # The maximum size of data stored in this column. validates_length_of
+  # may further refine this amount but this is just what the database
+  # is capable of storing.
+  attr_accessor :limit
+
+  # Creates a new column. Takes a block to assign the attributes.
+  def initialize
+    yield self if block_given?
+  end
+
+  # Is the type some sort of number
+  def number?
+    %w(integer float decimal).include? type.to_s
+  end
+
+end

--- a/lib/simple_form/column.rb
+++ b/lib/simple_form/column.rb
@@ -1,5 +1,5 @@
-# A Column object respresents the specs of an attribute as defined in
-# the database in an Object Mapper independent manor. A Object Mapper
+# A Column object represents the specs of an attribute as defined in
+# the database in an Object Mapper independent manner. A Object Mapper
 # independent version of ActiveRecord::ConnectionAdapters::ColumnDefinition
 class SimpleForm::Column
 

--- a/lib/simple_form/components/readonly.rb
+++ b/lib/simple_form/components/readonly.rb
@@ -13,9 +13,9 @@ module SimpleForm
       private
 
       def readonly_attribute?
-        object.class.respond_to?(:readonly_attributes) &&
+        object.class.respond_to?(:simple_form_readonly_attributes) &&
           object.persisted? &&
-          object.class.readonly_attributes.include?(attribute_name.to_s)
+          object.class.simple_form_readonly_attributes.include?(attribute_name.to_s)
       end
     end
   end

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -521,14 +521,14 @@ module SimpleForm
     end
 
     def find_attribute_column(attribute_name) #:nodoc:
-      if @object.respond_to?(:column_for_attribute)
-        @object.column_for_attribute(attribute_name)
+      if @object.class.respond_to?(:simple_form_column_for)
+        @object.class.simple_form_column_for(attribute_name)
       end
     end
 
     def find_association_reflection(association) #:nodoc:
-      if @object.class.respond_to?(:reflect_on_association)
-        @object.class.reflect_on_association(association)
+      if @object.class.respond_to?(:simple_form_association_for)
+        @object.class.simple_form_association_for(association)
       end
     end
 

--- a/lib/simple_form/oms.rb
+++ b/lib/simple_form/oms.rb
@@ -1,0 +1,2 @@
+require 'simple_form/oms/active_record' if defined? ActiveRecord
+require 'simple_form/oms/mongo_mapper' if defined? MongoMapper

--- a/lib/simple_form/oms/active_record.rb
+++ b/lib/simple_form/oms/active_record.rb
@@ -1,5 +1,16 @@
 module SimpleForm
+  # The general strategy is to let ActiveModel provide compatability
+  # between different object mappers. But there are a few additional
+  # abstractions that are needed. These additional abstractions are
+  # all prefixed with simple_form_ to reduce our pollution of the
+  # object mapper's namespace.
   module Oms
+
+    # ActiveRecord extensions to complete the object mapper abstraction.
+    #
+    # ActiveRecord is the gold standard of object mappers. When adding
+    # support for additional object mappers you MUST implement every
+    # method in this module.
     module ActiveRecord
 
       # An instance of SimpleForm::Column that describes the column
@@ -12,6 +23,8 @@ module SimpleForm
         end
       end
 
+      # An instance of SimpleForm::Association that describe the
+      # relationship between two objects.
       def simple_form_association_for attribute
         ar_assoc = reflect_on_association attribute
         return unless ar_assoc
@@ -21,6 +34,11 @@ module SimpleForm
           sf_assoc.name = ar_assoc.name
           sf_assoc.options = ar_assoc.options
         end
+      end
+
+      # Proxy to real method. Just to provide common interface
+      def simple_form_readonly_attributes
+        readonly_attributes
       end
 
     end

--- a/lib/simple_form/oms/active_record.rb
+++ b/lib/simple_form/oms/active_record.rb
@@ -1,0 +1,30 @@
+module SimpleForm
+  module Oms
+    module ActiveRecord
+
+      # An instance of SimpleForm::Column that describes the column
+      def simple_form_column_for attribute
+        ar_col = columns_hash[attribute.to_s]
+        return unless ar_col
+        SimpleForm::Column.new do |sf_col|
+          sf_col.type = ar_col.type
+          sf_col.limit = ar_col.limit
+        end
+      end
+
+      def simple_form_association_for attribute
+        ar_assoc = reflect_on_association attribute
+        return unless ar_assoc
+        SimpleForm::Association.new do |sf_assoc|
+          sf_assoc.klass = ar_assoc.klass
+          sf_assoc.macro_method = ar_assoc.macro_method
+          sf_assoc.name = ar_assoc.name
+          sf_assoc.options = ar_assoc.options
+        end
+      end
+
+    end
+  end
+end
+
+ActiveRecord::Base.extend SimpleForm::Oms::ActiveRecord

--- a/lib/simple_form/oms/mongo_mapper.rb
+++ b/lib/simple_form/oms/mongo_mapper.rb
@@ -1,10 +1,13 @@
 module SimpleForm
   module Oms
+
+    # MongoMapper extensions to complete the object mapper abstraction.
     module MongoMapper
       extend ActiveSupport::Concern
 
       module ClassMethods
-        # Returns a SimpleForm::Column that describes the attribute 
+
+        # An instance of SimpleForm::Column that describes the column 
         def simple_form_column_for attribute
           mm_col = keys[attribute.to_s]
           return unless mm_col
@@ -14,7 +17,8 @@ module SimpleForm
           end
         end
 
-        # Returns a SimpleForm::Association that describes the relationship
+        # An instance of SimpleForm::Association that describe the
+        # relationship between two objects.
         def simple_form_association_for attribute
           mm_assoc = associations[attribute]
           return unless mm_assoc
@@ -31,9 +35,9 @@ module SimpleForm
         end
 
         # MongoMapper doesn't support readonly attributes
-        def readonly_attributes; [] end
-      end
+        def simple_form_readonly_attributes; [] end
 
+      end
     end
   end
 end

--- a/lib/simple_form/oms/mongo_mapper.rb
+++ b/lib/simple_form/oms/mongo_mapper.rb
@@ -1,0 +1,42 @@
+module SimpleForm
+  module Oms
+    module MongoMapper
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Returns a SimpleForm::Column that describes the attribute 
+        def simple_form_column_for attribute
+          mm_col = keys[attribute.to_s]
+          return unless mm_col
+          SimpleForm::Column.new do |sf_col|
+            sf_col.type = mm_col.type.name.underscore.to_sym
+            sf_col.limit = nil # Mongo doesn't have limits :)
+          end
+        end
+
+        # Returns a SimpleForm::Association that describes the relationship
+        def simple_form_association_for attribute
+          mm_assoc = associations[attribute]
+          return unless mm_assoc
+          SimpleForm::Association.new do |sf_assoc|
+            sf_assoc.klass = mm_assoc.klass
+            sf_assoc.name = mm_assoc.name
+            sf_assoc.macro = case mm_assoc.class.name
+              when /BelongsTo/ then :belongs_to
+              when /One/ then :has_one
+              when /Many/ then :has_many
+            end
+            sf_assoc.options = mm_assoc.options
+          end
+        end
+
+        # MongoMapper doesn't support readonly attributes
+        def readonly_attributes; [] end
+      end
+
+    end
+  end
+end
+
+MongoMapper::Document.plugin SimpleForm::Oms::MongoMapper
+MongoMapper::EmbeddedDocument.plugin SimpleForm::Oms::MongoMapper

--- a/test/assoc_test.rb
+++ b/test/assoc_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class AssocTest < ActiveSupport::TestCase
+
+  test 'initialize via constructor block' do
+    actual = SimpleForm::Association.new do |assoc|
+      assoc.klass = Company
+      assoc.macro = :belongs_to
+      assoc.name = :company
+      assoc.options[:foreign_key] = 'parent_company_id'
+    end
+    assert_equal Company, actual.klass
+    assert_equal :belongs_to, actual.macro
+    assert_equal :company, actual.name
+    assert_equal 'parent_company_id', actual.options[:foreign_key]
+  end
+
+end

--- a/test/column_test.rb
+++ b/test/column_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ColumnTest < ActiveSupport::TestCase
+
+  test 'initialize via contructors block' do
+    actual = SimpleForm::Column.new do |col|
+      col.type = :string
+      col.limit = 255
+    end
+    assert_equal :string, actual.type
+    assert_equal 255, actual.limit
+  end
+
+  test 'can identify number' do
+    assert !SimpleForm::Column.new {|c| c.type = :string}.number?
+    assert SimpleForm::Column.new {|c| c.type = :integer}.number?
+    assert SimpleForm::Column.new {|c| c.type = :float}.number?
+    assert SimpleForm::Column.new {|c| c.type = :decimal}.number?
+  end
+
+end

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -9,7 +9,10 @@ class IsolatedLabelTest < ActionView::TestCase
 
   def with_label_for(object, attribute_name, type, options={})
     with_concat_form_for(object) do |f|
-      options[:reflection] = Association.new(Company, :company, {}) if options.delete(:setup_association)
+      options[:reflection] = SimpleForm::Association.new do |assoc|
+        assoc.klass = Company
+        assoc.name = :company
+      end if options.delete(:setup_association)
       SimpleForm::Inputs::Base.new(f, attribute_name, nil, type, options).label
     end
   end

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -62,8 +62,12 @@ class ErrorTest < ActionView::TestCase
   end
 
   test 'error should find errors on attribute and association' do
+    reflection = SimpleForm::Association.new do |assoc|
+      assoc.klass = Company
+      assoc.name = :company
+    end
     with_error_for @user, :company_id, as: :select,
-      error_method: :to_sentence, reflection: Association.new(Company, :company, {})
+      error_method: :to_sentence, reflection: reflection
     assert_select 'span.error', 'must be valid and company must be present'
   end
 

--- a/test/form_builder/hint_test.rb
+++ b/test/form_builder/hint_test.rb
@@ -105,7 +105,11 @@ class HintTest < ActionView::TestCase
     store_translations(:en, simple_form: { hints: {
       user: { company: 'My company!' }
     } } ) do
-      with_hint_for @user, :company_id, as: :string, reflection: Association.new(Company, :company, {})
+      reflection = SimpleForm::Association.new do |assoc|
+        assoc.klass = Company
+        assoc.name = :company
+      end
+      with_hint_for @user, :company_id, as: :string, reflection: reflection
       assert_select 'span.hint', /My company!/
     end
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -167,7 +167,7 @@ class User
     end
   end
 
-  def self.readonly_attributes
+  def self.simple_form_readonly_attributes
     ["credit_card"]
   end
 end


### PR DESCRIPTION
Initial support for ActiveRecord and MongoMapper. Provides obvious place to
add support for addition object mappers and to enhance additional support
needed on ActiveRecord and MongoMapper.

Browing through the MANY tickets regarding adding an object mapper abstraction
it seems the preferred method is to try to let ActiveModel handle most of the
abstraction and just extend the various object matters where ActiveModel is
not abstracting enough. This way most of the SimpleForm code does not care
what object mapper is being used.

Is seems to me there are two classes of methods that we need to extend the
object mappers with.
1. Methods that return simple data. A great example of this is the
   "readonly_attributes" method. SimpleForm uses this method that ActiveRecord
   provides but an object mapper like MongoMapper doesn't have the concept of
   read only attributes. So in this case we take the simple approach and simply
   mimic the ActiveRecord method by returning an array (just like ActiveRecord)
   which is empty (since the concept is not supported).
2. Methods that return complex data. A good example of this is
   "reflect_on_association". This returns an ActiveRecord-specific data
   structure. So in this case I made all data mappers (AR and MM) return a
   object mapper independent data structure (SimpleForm::Association). Because
   I am returning an SimpleForm specific data structure I have prefixed these
   methods with "simple_form_" so we reduce poluting the object mapper's
   namespace.

This second style method is basically what the testing is already doing. We
are just moving those object mapper independent data structures into the code
instead of having them only used in testing.

I have no doubt that this patch is missing stuff we will need down the road.
I am only using pieces of SimpleForm for my project so there may be areas where
we need more abstraction methods added to the object mappers. Obviously others
are also interested in other object mappers (DataMapper, Mongoid, etc). I feel
like that can come with time by additional patches. Right now we just need a
place to start. An obvious place to put these abstraction methods. Otherwise
we will continue to have dozens of issues where everybody want it but it cannot
get off the ground.

Regarding testing, I did add testing for the two object mapper independent
objects I added (Column and Association). But I was unsure the approach to take
regarding testing the abstraction methods that we add to the object mappers.
I was unsure if we wanted to required the tests to have all those database
types available. Or maybe have tests but skip ones not available. In general
the abstraction methods are simple. Just copying data from the object mapper
specific data structures to the object mapper independent data structures.

If you have suggestions on how to improve this patch I am open and ready to
follow suggestions. But I want to ensure we don't let perfection get in the
way of progress. For me it is ok if we have to refactor our approach as we add
more object mappers in the future. Sorry to be long winded. :)
