### PR TITLE
New test to cover placeholder failure

### DIFF
--- a/test/inputs/text_input_test.rb
+++ b/test/inputs/text_input_test.rb
@@ -12,6 +12,13 @@ class TextInputTest < ActionView::TestCase
     assert_select 'textarea.text[placeholder="Put in some text"]'
   end
 
+  test 'input generates a placeholder from the translations' do
+    store_translations(:en, simple_form: { placeholders: { user: { name: "placeholder from i18n en.simple_form.placeholders.user.name" } } }) do
+      with_input_for @user, :name, :text
+      assert_select 'textarea.text[placeholder="placeholder from i18n en.simple_form.placeholders.user.name"]'
+    end
+  end
+
   test 'input gets maxlength from column definition for text attributes' do
     with_input_for @user, :description, :text
     assert_select 'textarea.text[maxlength="200"]'


### PR DESCRIPTION
In v3.1.0 I've run into a situation where i18n.t() is run twice on the placeholder.  This passes the existing tests because the output is matches:

`f.input :name, :placeholder => "User name"` will output 
```
<input name="user[name]" placeholder="User name">
``` 

It passes the current test suite but, oddly, this Ruby code will also pass: `f.input :name, :placeholder => "foo.bar.user name"`

It looks as though something is causing a situation like `I18n.t(I18n.t(placeholder))`

I think it may be the way `translate_from_namespace` is implemented combined with an interaction with this line: `placeholder.is_a?(String) ? placeholder : translate_from_namespace(:placeholders)`.  Perhaps placeholder has been assigned but isn't a String causing it to be run again.
