### PR TITLE
Add disabled class to label's additional classes

### DIFF
--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -42,7 +42,7 @@ module SimpleForm
 
       def label_html_options
         label_html_classes = SimpleForm.additional_classes_for(:label) {
-          [input_type, required_class, SimpleForm.label_class].compact
+          [input_type, required_class, disabled_class, SimpleForm.label_class].compact
         }
 
         label_options = html_options_for(:label, label_html_classes)

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -29,6 +29,16 @@ class LabelTest < ActionView::TestCase
     assert_select 'label.string.required[for=validating_user_name]', /Name/
   end
 
+  test 'builder adds a disabled class to label if the attribute is disabled' do
+    with_label_for @validating_user, :name, disabled: true
+    assert_select 'label.string.disabled[for=validating_user_name]', /Name/
+  end
+
+  test 'builder does not add a disabled class to label if the attribute is not disabled' do
+    with_label_for @validating_user, :name, disabled: false
+    assert_no_select 'label.string.disabled[for=validating_user_name]', /Name/
+  end
+
   test 'builder escapes label text' do
     with_label_for @user, :name, label: '<script>alert(1337)</script>', required: false
     assert_no_select 'label.string script'


### PR DESCRIPTION
Adds disabled class to the attribute label so that it might also be
styled when the input is disabled