### PR TITLE
Can't set collection for configured custom value input

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -508,8 +508,8 @@ module SimpleForm
     # collection is given.
     def default_input_type(attribute_name, column, options)
       return options[:as].to_sym if options[:as]
-      return :select             if options[:collection]
       custom_type = find_custom_type(attribute_name.to_s) and return custom_type
+      return :select             if options[:collection]
 
       input_type = column.try(:type)
       case input_type

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -46,6 +46,17 @@ class FormBuilderTest < ActionView::TestCase
     end
   end
 
+  test 'builder does not override custom input mappings for custom collection' do
+    swap SimpleForm, input_mappings: { /gender$/ => :check_boxes } do
+      with_concat_form_for @user do |f|
+        f.input :gender, collection: [:male, :female]
+      end
+
+      assert_no_select 'select option', 'Male'
+      assert_select 'input[type=checkbox][value=male]'
+    end
+  end
+
   test 'builder allows to skip input_type class' do
     swap SimpleForm, generate_additional_classes_for: [:label, :wrapper] do
       with_form_for @user, :post_count


### PR DESCRIPTION
Hello everyone! I have the following configuration for my custom form fields:
```ruby
config.input_mappings = {/bodytype/ => :check_boxes}
```
And would like to provide my custom collection generation helper for this kind of input, like this:
```ruby
f.input :bodytype, :collection => bodytype_collection
````
But it doesn't work for me because of explicit return in `default_input_type` method, my quick and dirty solution was simple, bump custom time detection statements top. Is that an issue, or it is impossible to use :collection option by design?