### PR TITLE
Update docs regarding item_wrapper_tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ end
 ```
 
 For check boxes and radio buttons you can remove the label changing `boolean_style` from default value `:nested` to `:inline`.
-Also, `item_wrapper_tag` will not work when `boolean_style` is set to `:nested`.
 
 Example:
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -90,8 +90,7 @@ SimpleForm.setup do |config|
   # config.collection_wrapper_class = nil
 
   # You can wrap each item in a collection of radio/check boxes with a tag,
-  # defaulting to :span. Please note that when using :boolean_style = :nested,
-  # SimpleForm will force this option to be a label.
+  # defaulting to :span.
   # config.item_wrapper_tag = :span
 
   # You can define a class to use in all item wrappers. Defaulting to none.


### PR DESCRIPTION
Item_wrapper_tag configuration option in 3.x behaves independently, without any limitations imposed by nested boolean_style as mentioned in the documentation.

Update readme and a comment inside the initializer.

Closes #1224.