### PR TITLE
Fix method reflection for ruby 2.1

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -35,7 +35,7 @@ module SimpleForm
       # reuse the method for nested boolean style, but with no unchecked value,
       # which won't generate the hidden checkbox. This is the default functionality
       # in Rails > 3.2.1, and is backported in SimpleForm AV helpers.
-      def build_check_box(unchecked_value = unchecked_value)
+      def build_check_box(unchecked_value = unchecked_value())
         @builder.check_box(attribute_name, input_html_options, checked_value, unchecked_value)
       end
 


### PR DESCRIPTION
Fixes warning:

        /home/badosu/.gem/ruby/2.2.1/gems/simple_form-2.1.2/lib/simple\
        _form/inputs/boolean_input.rb:37:
        warning: circular argument reference - unchecked_value