### PR TITLE
Bug/fix circular argument reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem 'activemodel', '~> 3.2.0'
 gem 'actionpack', '~> 3.2.0'
 gem 'rake'
 gem 'rdoc'
+gem 'test-unit'
 gem 'mocha', '~> 0.13.0', :require => false
 gem 'tzinfo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
+    power_assert (0.2.3)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -57,6 +58,8 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    test-unit (3.0.9)
+      power_assert
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
@@ -75,4 +78,5 @@ DEPENDENCIES
   rake
   rdoc
   simple_form!
+  test-unit
   tzinfo

--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -34,7 +34,7 @@ module SimpleForm
       # reuse the method for nested boolean style, but with no unchecked value,
       # which won't generate the hidden checkbox. This is the default functionality
       # in Rails > 3.2.1, and is backported in SimpleForm AV helpers.
-      def build_check_box(unchecked_value = unchecked_value)
+      def build_check_box(unchecked_value = unchecked_value())
         @builder.check_box(attribute_name, input_html_options, checked_value, unchecked_value)
       end
 


### PR DESCRIPTION
Hi,

We're using Simple Form 2.1 with a legacy Rails 3.2 app. Rails compatibility with Ruby 2.2 was fixed in the 3-2-stable branch, but there was a 'circular reference warning' with the current Simple Form 2.1 release. 

Unfortunately we can't go to Simple Form 3+ since it's not compatible with Rails 3.2 so I fixed the circular reference (I created the bug fix branch from the 'v2.1' tag).

I'm getting a lot of warnings running the tests with Ruby 2.2.1 but it looks like they're still passing.