### PR TITLE
Try convert @object to model in case we got decorated object

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -39,6 +39,7 @@ module SimpleForm
 
     def initialize(*) #:nodoc:
       super
+      @object   = convert_to_model(@object)
       @defaults = options[:defaults]
       @wrapper  = SimpleForm.wrapper(options[:wrapper] || SimpleForm.default_wrapper)
     end

--- a/test/form_builder/association_test.rb
+++ b/test/form_builder/association_test.rb
@@ -15,6 +15,12 @@ class AssociationTest < ActionView::TestCase
     end
   end
 
+  test 'builder association works with decorated object responsive to #to_model' do
+    assert_nothing_raised do
+      with_association_for @decorated_user, :company
+    end
+  end
+
   test 'builder association with a block calls simple_fields_for' do
     simple_form_for @user do |f|
       f.association :posts do |posts_form|

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -36,6 +36,11 @@ class ErrorTest < ActionView::TestCase
     assert_select 'span.error', "cannot be blank"
   end
 
+  test 'error generates messages with decorated object responsive to #to_model' do
+    with_error_for @decorated_user, :name
+    assert_select 'span.error', "cannot be blank"
+  end
+
   test 'error generates messages for attribute with one error when using first' do
     swap SimpleForm, error_method: :first do
       with_error_for @user, :age

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -31,6 +31,12 @@ class FormBuilderTest < ActionView::TestCase
     end
   end
 
+  test 'builder works with decorated object responsive to #to_model' do
+    assert_nothing_raised do
+      with_form_for @decorated_user, :name
+    end
+  end
+
   test 'builder input allows a block to configure input' do
     with_form_for @user, :name do
       text_field_tag :foo, :bar, id: :cool

--- a/test/form_builder/hint_test.rb
+++ b/test/form_builder/hint_test.rb
@@ -19,6 +19,11 @@ class HintTest < ActionView::TestCase
     assert_select 'span.hint', 'Use with care...'
   end
 
+  test 'hint is generated with decorated object responsive to #to_model' do
+    with_hint_for @decorated_user, :name, hint: 'Use with care...'
+    assert_select 'span.hint', 'Use with care...'
+  end
+
   test 'hint does not modify the options hash' do
     options = { hint: 'Use with care...' }
     with_hint_for @user, :name, options

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -14,6 +14,11 @@ class LabelTest < ActionView::TestCase
     assert_select 'label.string[for=user_name]', /Name/
   end
 
+  test 'builder generates a label for the attribute with decorated object responsive to #to_model' do
+    with_label_for @decorated_user, :name
+    assert_select 'label.string[for=user_name]', /Name/
+  end
+
   test 'builder generates a label for the boolean attrbiute' do
     with_label_for @user, :name, as: :boolean
     assert_select 'label.boolean[for=user_name]', /Name/

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -19,6 +19,12 @@ Relation = Struct.new(:records) do
   alias_method :to_ary, :records
 end
 
+Decorator = Struct.new(:object) do
+  def to_model
+    object
+  end
+end
+
 Picture = Struct.new(:id, :name) do
   extend ActiveModel::Naming
   include ActiveModel::Conversion

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,7 @@ class ActionView::TestCase
 
   def setup_users(extra_attributes = {})
     @user = User.build(extra_attributes)
+    @decorated_user = Decorator.new(@user)
 
     @validating_user = ValidatingUser.build({
       name: 'Tester McTesterson',


### PR DESCRIPTION
SimpleForm expects `@object` will be ActiveRecord instance and trying to call
- `@object.send(attribute_name)`
- `@object.column_for_attribute(attribute_name)`
- `@object.class.reflect_on_association(association)`

In case we use decorated (presenter) object when passing to `simple_form_for` association input does not work as expected.

Idea is to follow `@object.to_model` convention when trying to interact with `@object` as ActiveRecord instance, like Rails does in [FormHelper](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/form_helper.rb#L458) for example.

I will add tests if idea generally is OK.
