### PR TITLE
Use `button` instead of `submit` when a block is given.

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -192,6 +192,23 @@ module SimpleForm
       input(attribute, options.merge(reflection: reflection))
     end
 
+    # Creates a submit button.
+    #
+    # This augments the original button implementation to generate a button element
+    # with a submit action when a block is given. Otherwise, it falls back to the
+    # original submit helper.
+    def submit_button(*args, &block)
+      if block_given?
+        options = args.extract_options!.dup
+        options[:type] = :submit
+        options[:name] ||= 'commit'
+        args << options
+        button_button(options, &block)
+      else
+        submit(*args)
+      end
+    end
+
     # Creates a button:
     #
     #   form_for @user do |f|

--- a/test/form_builder/button_test.rb
+++ b/test/form_builder/button_test.rb
@@ -44,4 +44,13 @@ class ButtonTest < ActionView::TestCase
       assert_select 'form button.button[type=submit]', 'Save!'
     end
   end
+
+  test 'builder generates a button element for submit buttons when block given' do
+    with_concat_form_for :post do |f|
+      f.button :submit do
+        'Save from Block!'
+      end
+    end
+    assert_select 'form button.button[type=submit]', 'Save from Block!'
+  end
 end


### PR DESCRIPTION
The submit helper does not accept blocks, and this unifies the behaviour of the different button types.