### PR TITLE
Open activemodel and actionpack dependencies to enable Rails5 support

### DIFF
--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "simple_form"
 
-  s.add_dependency('activemodel', '~> 4.0')
-  s.add_dependency('actionpack', '~> 4.0')
+  s.add_dependency('activemodel', '>= 4.0')
+  s.add_dependency('actionpack', '>= 4.0')
 end


### PR DESCRIPTION
Current dependencies doesn't permit to use simple_form with edge Rails, so change them a bit.