### PR TITLE
Add example on how to set html attributes on specific collection items

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,20 @@ can give prompt as:
 ```ruby
 f.input :age, collection: 18..60, prompt: "Select your age", selected: 21
 ```
-Extra options are passed into helper [`collection_select`](http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select).
+Extra options are passed into helper [`collection_select`](http://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select). Thus it is possible to set individual HTML attributes on select options:
+
+```ruby
+f.input :attrib, collection: [['name1', 'value1', class: 'warn'], ['name2', 'value2']]
+```
+This will output:
+
+```html
+<select name="model[attrib]">
+  <option value=""></option>
+  <option class="warn" value="value1">name1</option>
+  <option value="value2">name2</option>
+</select>
+```
 
 It is also possible to create grouped collection selects, that will use the html *optgroup* tags, like this:
 


### PR DESCRIPTION
When searching the internet I came upon "helpful" hints like that one:

http://stackoverflow.com/questions/17554748/how-do-i-add-html-attributes-to-select-options-with-simple-form-rails

I took quite some time before I figured that this was not the right solution. To not let others fall into this trap, I propose to add this to the documentation.