### PR TITLE
Remove nested (slow) i18n lookups

### DIFF
--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -173,22 +173,10 @@ module SimpleForm
         model_names = lookup_model_names.dup
         lookups     = []
 
-        while !model_names.empty?
-          joined_model_names = model_names.join(".")
-          model_names.shift
+  lookups << :"#{model_names.join(".")}.#{reflection_or_attribute_name}"
+  lookups << default
 
-          lookups << :"#{joined_model_names}.#{lookup_action}.#{reflection_or_attribute_name}"
-          lookups << :"#{joined_model_names}.#{lookup_action}.#{reflection_or_attribute_name}_html"
-          lookups << :"#{joined_model_names}.#{reflection_or_attribute_name}"
-          lookups << :"#{joined_model_names}.#{reflection_or_attribute_name}_html"
-        end
-        lookups << :"defaults.#{lookup_action}.#{reflection_or_attribute_name}"
-        lookups << :"defaults.#{lookup_action}.#{reflection_or_attribute_name}_html"
-        lookups << :"defaults.#{reflection_or_attribute_name}"
-        lookups << :"defaults.#{reflection_or_attribute_name}_html"
-        lookups << default
-
-        t(lookups.shift, scope: :"#{i18n_scope}.#{namespace}", default: lookups).presence
+  t(lookups.shift, scope: :"#{i18n_scope}.#{namespace}", default: lookups).presence
       end
 
       def merge_wrapper_options(options, wrapper_options)


### PR DESCRIPTION
SimpleForm looks up for translation in a huge amount of places which
slows it down when you use nested forms.

See issue: plataformatec#1227

Removed the nested lookups code (including the while-loop) completely