### PR TITLE
Allow no errors hash

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -38,19 +38,29 @@ module SimpleForm
       end
 
       def errors_on_attribute
-        object.errors[attribute_name]
+        object_errors[attribute_name] || []
       end
 
       def full_errors_on_attribute
-        object.errors.full_messages_for(attribute_name)
+        object_errors.full_messages_for(attribute_name) || []
       end
 
       def errors_on_association
-        reflection ? object.errors[reflection.name] : []
+        reflection ? object_errors[reflection.name] : []
+      end
+
+      def object_errors
+        @object_errors ||= begin
+          if !object.errors.nil? && object.errors.respond_to?(:[]) && !object.errors.is_a?(Array)
+            object.errors
+          else
+            {}
+          end
+        end
       end
 
       def full_errors_on_association
-        reflection ? object.errors.full_messages_for(reflection.name) : []
+        reflection ? object_errors.full_messages_for(reflection.name) : []
       end
 
       def has_custom_error?

--- a/test/form_builder/error_notification_test.rb
+++ b/test/form_builder/error_notification_test.rb
@@ -91,4 +91,11 @@ class ErrorNotificationTest < ActionView::TestCase
     end
   end
 
+  test 'error notification accepts a nil errors collection' do
+    stub_any_instance User, :errors, nil do
+      with_error_notification_for @user
+      assert_no_select 'p.error_notification'
+    end
+  end
+
 end

--- a/test/form_builder/error_notification_test.rb
+++ b/test/form_builder/error_notification_test.rb
@@ -76,4 +76,19 @@ class ErrorNotificationTest < ActionView::TestCase
       assert_select 'p.error_notification b', 'usuário'
     end
   end
+
+  test 'error notification accepts arrays of errors' do
+    stub_any_instance User, :errors, ["ERROR!"] do
+      with_error_notification_for @user
+      assert_select 'p.error_notification', 'Please review the problems below:'
+    end
+  end
+
+  test 'error notification accepts hashes of errors' do
+    stub_any_instance User, :errors, {:field1 => "ERROR!"} do
+      with_error_notification_for @user
+      assert_select 'p.error_notification', 'Please review the problems below:'
+    end
+  end
+
 end


### PR DESCRIPTION
If the object used by the form doesn't have the typical ActiveModel::Errors collection, simple_form throws exceptions.  Applications might be using objects that are not from AR, like in cases that they are SOA objects.  If the application has decided to use some other method of showing errors, or is even just using a hash instead of a full-blown ActiveModel::Errors object, simple_form should allow it.