### PR TITLE
Use symbols instead of strings for #send

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -207,8 +207,8 @@ module SimpleForm
       options = args.extract_options!.dup
       options[:class] = [SimpleForm.button_class, options[:class]].compact
       args << options
-      if respond_to?("#{type}_button")
-        send("#{type}_button", *args, &block)
+      if respond_to?(:"#{type}_button")
+        send(:"#{type}_button", *args, &block)
       else
         send(type, *args, &block)
       end

--- a/lib/simple_form/inputs/collection_radio_buttons_input.rb
+++ b/lib/simple_form/inputs/collection_radio_buttons_input.rb
@@ -6,7 +6,7 @@ module SimpleForm
 
         merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 
-        @builder.send("collection_#{input_type}",
+        @builder.send(:"collection_#{input_type}",
           attribute_name, collection, value_method, label_method,
           input_options, merged_input_options,
           &collection_block_for_nested_boolean_style


### PR DESCRIPTION
A tiny performance enhancement. Using symbol interpolation instead of strings is about 50% faster when being used with `#send`. The overall enhancement is very small since these methods are being called relatively rarely.
