### PR TITLE
Update gem dependency to support rails 5 alpha

### DIFF
--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "simple_form"
 
-  s.add_dependency('activemodel', '~> 4.0')
-  s.add_dependency('actionpack', '~> 4.0')
+  s.add_dependency('activemodel', '>= 4.0')
+  s.add_dependency('actionpack', '>= 4.0')
 end


### PR DESCRIPTION
Hi @carlosantoniodasilva 

Just updated gemspec to support activemodel >= 4 && actionpack >= 4 to support rails edge version.

Please review and merge.

Thanks