### PR TITLE
Yield options instead of options[:label] for label_text

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -84,7 +84,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
 
   # How the label text should be generated altogether with the required text.
   mattr_accessor :label_text
-  @@label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+  @@label_text = lambda { |label, required, options| "#{required} #{label}" }
 
   # You can define the class to be used on all labels. Defaults to none.
   mattr_accessor :label_class

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -33,7 +33,7 @@ module SimpleForm
 
       def label_text(wrapper_options = nil)
         label_text = options[:label_text] || SimpleForm.label_text
-        label_text.call(html_escape(raw_label_text), required_label_text, options[:label].present?).strip.html_safe
+        label_text.call(html_escape(raw_label_text), required_label_text, options).strip.html_safe
       end
 
       def label_target

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -107,15 +107,22 @@ class LabelTest < ActionView::TestCase
     end
   end
 
+  test 'label_text yields with options' do
+    swap SimpleForm, label_text: lambda { |label, required, options| "#{required} #{label} #{options[:icon]}" } do
+      with_label_for @user, :time_zone, icon: :calendar
+      assert_select 'label[for=user_time_zone]', /calendar/
+    end
+  end
+
   test 'builder allows custom formatting when label is explicitly specified' do
-    swap SimpleForm, label_text: lambda { |l, r, explicit_label| explicit_label ? l : "#{l.titleize}:" } do
+    swap SimpleForm, label_text: lambda { |l, r, options| options[:label].present? ? l : "#{l.titleize}:" } do
       with_label_for @user, :time_zone, 'What is your home time zone?'
       assert_select 'label[for=user_time_zone]', 'What is your home time zone?'
     end
   end
 
   test 'builder allows custom formatting when label is generated' do
-    swap SimpleForm, label_text: lambda { |l, r, explicit_label| explicit_label ? l : "#{l.titleize}:" } do
+    swap SimpleForm, label_text: lambda { |l, r, options| options[:label].present? ? l : "#{l.titleize}:" } do
       with_label_for @user, :time_zone
       assert_select 'label[for=user_time_zone]', 'Time Zone:'
     end


### PR DESCRIPTION
This gives more flexibility when overriding `label_text`

E.g.

``` ruby
config.label_text = lambda { |label, required, options| label_text =  "#{required} #{label}"; options[:icon] ? fa_icon(options[:icon], :text => label_text) : label_text }
```

The old `explicit_label` functionality can still be used

``` ruby
config.label_text = lambda { |label, required, options| explicit_label = options[:label].present? }
``
```
