### PR TITLE
Merge attributes with wrapper_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+
+### bug fix
+  * Fix `merge_wrapper_options` to correctly merge options with duplicated keys. [@herminiotorres](https://github.com/herminiotorres)
+  Closes [#1278](https://github.com/plataformatec/simple_form/issues/1278).
+
 ## 3.2.0
 
 ### bug fix

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -189,9 +189,14 @@ module SimpleForm
 
       def merge_wrapper_options(options, wrapper_options)
         if wrapper_options
-          options.merge(wrapper_options) do |_, oldval, newval|
-            if Array === oldval
-              oldval + Array(newval)
+          wrapper_options.merge(options) do |key, oldval, newval|
+            case key.to_s
+            when "class"
+              Array(oldval) + Array(newval)
+            when "data", "aria"
+              oldval.merge(newval)
+            else
+              newval
             end
           end
         else

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -242,6 +242,36 @@ class WrapperTest < ActionView::TestCase
     assert_select "section.custom_wrapper div.another_wrapper input.string"
   end
 
+  test "input attributes class will merge with wrapper_options' classes" do
+    swap_wrapper :default, custom_wrapper_with_input_class do
+      with_concat_form_for @user do |f|
+        concat f.input :name, input_html: { class: 'another-class' }
+      end
+    end
+
+    assert_select "div.custom_wrapper input.string.inline-class.another-class"
+  end
+
+  test "input with data attributes will merge with wrapper_options' data" do
+    swap_wrapper :default, custom_wrapper_with_input_data_modal do
+      with_concat_form_for @user do |f|
+        concat f.input :name, input_html: { data: { modal: 'another-data', target: 'merge-data' } }
+      end
+    end
+
+    assert_select "input[data-wrapper='data-wrapper'][data-modal='another-data'][data-target='merge-data']"
+  end
+
+  test "input with aria attributes will merge with wrapper_options' aria" do
+    swap_wrapper :default, custom_wrapper_with_input_aria_modal do
+      with_concat_form_for @user do |f|
+        concat f.input :name, input_html: { aria: { modal: 'another-aria', target: 'merge-aria' } }
+      end
+    end
+
+    assert_select "input[aria-wrapper='aria-wrapper'][aria-modal='another-aria'][aria-target='merge-aria']"
+  end
+
   test 'input accepts attributes in the DSL' do
     swap_wrapper :default, custom_wrapper_with_input_class do
       with_concat_form_for @user do |f|

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -263,6 +263,8 @@ class WrapperTest < ActionView::TestCase
   end
 
   test "input with aria attributes will merge with wrapper_options' aria" do
+    skip unless ActionPack::VERSION::MAJOR == '4' && ActionPack::VERSION::MINOR >= '2'
+
     swap_wrapper :default, custom_wrapper_with_input_aria_modal do
       with_concat_form_for @user do |f|
         concat f.input :name, input_html: { aria: { modal: 'another-aria', target: 'merge-aria' } }

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -91,6 +91,20 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_input_data_modal
+    SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.use :label
+      b.use :input, data: { modal: 'data-modal', wrapper: 'data-wrapper' }
+    end
+  end
+
+  def custom_wrapper_with_input_aria_modal
+    SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.use :label
+      b.use :input, aria: { modal: 'aria-modal', wrapper: 'aria-wrapper' }
+    end
+  end
+
   def custom_wrapper_with_label_class
     SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
       b.use :label, class: 'inline-class'


### PR DESCRIPTION
As described in the #1278 issue modified the method of `merge_wrapper_options` to support duplicated values.

- If sending a new wrapper it returns the new.
- If sending a new wrapper with same attributes merge with the older.

closes #1278