### PR TITLE
Fix input_field not receiving the wrapper options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### bug fix
   * `date/time/datetime` inputs now correctly generate the label `for` attribute when
   HTML5 compatibility is explicitly enabled. [@ericsullivan](https://github.com/ericsullivan)
+  * `input_field` now correctly generates extra options from the wrapper input config.
 
 ## 3.1.0
 

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -137,9 +137,15 @@ module SimpleForm
       options[:input_html] = options.except(:as, :boolean_style, :collection, :label_method, :value_method, *components)
       options = @defaults.deep_dup.deep_merge(options) if @defaults
 
-      input      = find_input(attribute_name, options)
-      wrapper    = find_wrapper(input.input_type, options)
-      components = components.concat([:input]).map { |component| SimpleForm::Wrappers::Leaf.new(component) }
+      input   = find_input(attribute_name, options)
+      wrapper = find_wrapper(input.input_type, options)
+
+      components.map! { |component| SimpleForm::Wrappers::Leaf.new(component) }
+      if input_component = wrapper.components.detect { |component| component.namespace == :input }
+        components.push input_component
+      else
+        components.push SimpleForm::Wrappers::Leaf.new(:input)
+      end
 
       SimpleForm::Wrappers::Root.new(components, wrapper.options.merge(wrapper: false)).render input
     end

--- a/test/form_builder/input_field_test.rb
+++ b/test/form_builder/input_field_test.rb
@@ -152,4 +152,12 @@ class InputFieldTest < ActionView::TestCase
       assert_select 'input[readonly="readonly"]'
     end
   end
+
+  test 'build input_field accepts extra attributes in the DSL' do
+    swap_wrapper :default, custom_wrapper_with_input_attributes do
+      with_input_field_for @user, :name
+    end
+
+    assert_select "input.string[data-modal=true]"
+  end
 end


### PR DESCRIPTION
Previously any option given to the wrapper `:input` config, like a class
name or data attribute, would not be passed down when generating an
input field. Now if you give any specific option to generate inputs with,
they will be also be picked up when using `input_field`.

Fixes #1230.