### PR TITLE
Add item_extra_html option for collection check/radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.X.X
+
+### enhancements
+  * Add the `item_extra_html` option for radio and checkbox collections.
+
 ## 3.2.0
 
 ### bug fix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     simple_form (3.2.0)
-      actionpack (~> 4.0)
-      activemodel (~> 4.0)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
 
 GEM
   remote: https://rubygems.org/
@@ -280,6 +280,3 @@ DEPENDENCIES
   rubinius-developer_tools
   rubysl (~> 2.0)
   simple_form!
-
-BUNDLED WITH
-   1.10.6

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -362,6 +362,8 @@ module SimpleForm
     #
     #   * item_wrapper_class       => the CSS class to use for item_wrapper_tag
     #
+    #   * item_extra_html          => A method accepting the item and value, returning an hash of extra HTML tags for the radio component
+    #
     #   * a block                  => to generate the label + radio or any other component.
     def collection_radio_buttons(method, collection, value_method, text_method, options = {}, html_options = {}, &block)
       SimpleForm::Tags::CollectionRadioButtons.new(@object_name, method, @template, collection, value_method, text_method, objectify_options(options), @default_options.merge(html_options)).render(&block)
@@ -415,6 +417,8 @@ module SimpleForm
     #   * item_wrapper_tag         => the tag to wrap each item in the collection.
     #
     #   * item_wrapper_class       => the CSS class to use for item_wrapper_tag
+    #
+    #   * item_extra_html          => A method accepting the item and value, returning an hash of extra HTML tags for the checkbox component
     #
     #   * a block                  => to generate the label + check box or any other component.
     def collection_check_boxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block)

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -12,6 +12,9 @@ module SimpleForm
           text  = value_for_collection(item, @text_method)
           default_html_options = default_html_options_for_collection(item, value)
           additional_html_options = option_html_attributes(item)
+          if @options[:item_extra_html]
+            additional_html_options.merge!(@options[:item_extra_html].call(item, value))
+          end
 
           rendered_item = yield item, value, text, default_html_options.merge(additional_html_options)
 

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -300,4 +300,11 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'collection input with check_boxes type and item_extra_html is included' do
+    with_input_for @user, :name, :check_boxes, collection: [['Jose', 1], ['Carlos', 2]],
+                          item_extra_html: -> (item, value) { { 'data-extra' => "#{item.first}-and-#{value}" } }
+    assert_select 'input[value="1"][data-extra="Jose-and-1"]'
+    assert_select 'input[value="2"][data-extra="Carlos-and-2"]'
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -423,4 +423,11 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'collection input with radio_buttons type and item_extra_html is included' do
+    with_input_for @user, :name, :radio_buttons, collection: [['Jose', 1], ['Carlos', 2]],
+                          item_extra_html: -> (item, value) { { 'data-extra' => "#{item.first}-and-#{value}" } }
+    assert_select 'input[value="1"][data-extra="Jose-and-1"]'
+    assert_select 'input[value="2"][data-extra="Carlos-and-2"]'
+  end
 end


### PR DESCRIPTION
Rationale behind this change is to be able to easily add "data-" attributes to checkboxes/radiobuttons depending on the value.

We use this to dynamically (with javascript) enable / disable options in a list depending on a choice made in another list

If there are easy ways to achieve this with existing simple_form methods, I am happy to hear them
