### PR TITLE
Add :valid_class on input wrapper when value is present and valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,7 +838,8 @@ The syntax looks like this:
 
 ```ruby
 config.wrappers tag: :div, class: :input,
-                error_class: :field_with_errors do |b|
+                error_class: :field_with_errors,
+                valid_class: :field_without_errors do |b|
 
   # Form extensions
   b.use :html5

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -6,7 +6,7 @@ SimpleForm.setup do |config|
   # stack. The options given below are used to wrap the
   # whole input.
   config.wrappers :default, class: :input,
-    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
     ## Extensions enabled by default
     # Any of these extensions can be disabled for a
     # given input by passing: `f.input EXTENSION_NAME => false`.

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -4,7 +4,7 @@ SimpleForm.setup do |config|
   config.button_class = 'btn btn-default'
   config.boolean_label_class = nil
 
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -18,7 +18,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -30,7 +30,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -42,7 +42,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'
@@ -51,7 +51,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -67,7 +67,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -81,7 +81,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -95,7 +95,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -108,7 +108,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -122,7 +122,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -7,7 +7,7 @@ SimpleForm.setup do |config|
   # does't provide styles for hints. You will need to provide your own CSS styles for hints.
   # Uncomment them to enable hints.
 
-  config.wrappers :vertical_form, class: :input, hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :vertical_form, class: :input, hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -20,7 +20,7 @@ SimpleForm.setup do |config|
     # b.use :hint,  wrap_with: { tag: :span, class: :hint }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'row', hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :horizontal_form, tag: 'div', class: 'row', hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -61,7 +61,7 @@ SimpleForm.setup do |config|
   # Note that you need to adapt this wrapper to your needs. If you need a 4
   # columns form then change the wrapper class to 'small-3', if you need
   # only two use 'small-6' and so on.
-  config.wrappers :inline_form, tag: 'div', class: 'column small-4', hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :inline_form, tag: 'div', class: 'column small-4', hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -79,7 +79,7 @@ SimpleForm.setup do |config|
   # Examples of use:
   # - wrapper_html: {class: 'row'}, custom_wrapper_html: {class: 'column small-12'}
   # - custom_wrapper_html: {class: 'column small-3 end'}
-  config.wrappers :customizable_wrapper, tag: 'div', error_class: :error do |b|
+  config.wrappers :customizable_wrapper, tag: 'div', error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.optional :readonly
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -231,7 +231,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
     SimpleForm::Wrappers::Root.new(builder.to_a, options)
   end
 
-  wrappers class: :input, hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+  wrappers class: :input, hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
     b.use :html5
 
     b.use :min_max

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -13,6 +13,16 @@ module SimpleForm
         object && object.respond_to?(:errors) && errors.present?
       end
 
+      def has_value?
+        return unless object && object.respond_to?(attribute_name)
+
+        object.send(attribute_name).present?
+      end
+
+      def valid?
+        !has_errors? && has_value?
+      end
+
       protected
 
       def error_text

--- a/lib/simple_form/wrappers/root.rb
+++ b/lib/simple_form/wrappers/root.rb
@@ -29,6 +29,7 @@ module SimpleForm
         end
         css << (options[:wrapper_error_class] || @defaults[:error_class]) if input.has_errors?
         css << (options[:wrapper_hint_class] || @defaults[:hint_class]) if input.has_hint?
+        css << (options[:wrapper_valid_class] || @defaults[:valid_class]) if input.valid?
         css.compact
       end
     end

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -243,4 +243,16 @@ class ErrorTest < ActionView::TestCase
       assert_no_select 'span.error'
     end
   end
+
+  # NO ERRORS
+
+  test 'input wrapper has valid class for present attribute without errors' do
+    @user.instance_eval do
+      undef errors
+      name = 'foo'
+    end
+
+    with_form_for @user, :name
+    assert_select '.input.field_without_errors'
+  end
 end

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -195,6 +195,7 @@ class FormBuilderTest < ActionView::TestCase
   test 'builder generates file for file columns' do
     @user.avatar = MiniTest::Mock.new
     @user.avatar.expect(:public_filename, true)
+    @user.avatar.expect(:!, false)
 
     with_form_for @user, :avatar
     assert_select 'form input#user_avatar.file'
@@ -203,6 +204,7 @@ class FormBuilderTest < ActionView::TestCase
   test 'builder generates file for attributes that are real db columns but have file methods' do
     @user.home_picture = MiniTest::Mock.new
     @user.home_picture.expect(:mounted_as, true)
+    @user.home_picture.expect(:!, false)
 
     with_form_for @user, :home_picture
     assert_select 'form input#user_home_picture.file'


### PR DESCRIPTION
##### Purpose

The purpose of this PR is to improve style support for inputs with validations. Simply put, the lack of an applied `:error_class` is not indicative of the attribute being valid. While this isn't a guaranteed method of determining if it is valid, it is as close as programmatically possible (AFAIK). See caveats below.
##### Logic

When a `:valid_class` is specified, it will be applied to an input wrapper given the following conditions:
1. Object exists.
2. Object responds to `:errors`.
3. There are no validation errors (e.g. validations passed or were not specified).
4. Object responds to the attribute method.
5. Return value of attribute method is present.
##### Changes
1. Added `:valid_class` declarations (similar to those for `:error_class`) on default wrappers.
2. Added `:has_value?` and `:valid?` to `SimpleForm::Components::Errors`.
3. Adjusted `SimpleForm::Wrappers::Root#html_classes` to apply `:valid_class` when applicable.
##### Known caveats

If an attribute is valid when `:blank?`, the `:valid_class` will not be applied. I am open to suggestions here, as this is the only hole in my logic, albeit an acceptable and predictable one (IMO).
##### Further notes

I adjusted two failing tests that were missing stubs, and added another test for this feature.

Please let me know if there's something else I should include. Thanks, cheers!
