### PR TITLE
Browsers do not support \A or \Z, but rails recommends them

### DIFF
--- a/lib/simple_form/components/pattern.rb
+++ b/lib/simple_form/components/pattern.rb
@@ -15,7 +15,7 @@ module SimpleForm
           pattern
         elsif (pattern_validator = find_pattern_validator) && (with = pattern_validator.options[:with])
           evaluate_format_validator_option(with).source
-        end
+        end.try { |p| p.to_s.gsub(/(?:(?!\\)|\A)\\A/, '^').gsub(/(?<!\\)\\[zZ]/, '$') }
       end
 
       def find_pattern_validator

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -67,7 +67,7 @@ module SimpleForm
       end
 
       def detect_common_display_methods(collection_classes = detect_collection_classes)
-        collection_translated = translate_collection if collection_classes == [Symbol]
+        collection_translated = translate_collection if collection_classes == [Symbol] || collection_classes == [NilClass, Symbol]
 
         if collection_translated || collection_classes.include?(Array)
           { label: :first, value: :second }

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -68,6 +68,11 @@ class StringInputTest < ActionView::TestCase
     assert_no_select 'input[pattern="\w+"]'
   end
 
+  test 'input converts \\A and \\Z to ^ and $ that browsers support' do
+    with_input_for @other_validating_user, :country, :string
+    assert_no_select 'input[pattern="^[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]$"]'
+  end
+
   test 'input infers pattern from attributes' do
     with_input_for @other_validating_user, :country, :string, pattern: true
     assert_select 'input[pattern="\w+"]'

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -253,6 +253,7 @@ class OtherValidatingUser < User
   validates_format_of :country, with: /\w+/
   validates_format_of :name, with: Proc.new { /\w+/ }
   validates_format_of :description, without: /\d+/
+  validates_format_of :postal_code, with: /\A[ABCEGHJKLMNPRSTVXY][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9][ABCEGHJKLMNPRSTVWXYZ][0-9]\Z/
 end
 
 class HashBackedAuthor < Hash


### PR DESCRIPTION
So translate to something close that the browser supports
