### PR TITLE
undefined method `where' for Array (returned from ActiveHash)

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -462,7 +462,7 @@ module SimpleForm
           conditions = reflection.options[:conditions]
           conditions = object.instance_exec(&conditions) if conditions.respond_to?(:call)
 
-          relation = relation.where(conditions)
+          relation = relation.where(conditions) if relation.respond_to?(:where)
           relation = relation.order(order) if relation.respond_to?(:order)
         end
 


### PR DESCRIPTION
- simple_form (3.2.1)
- active_hash (1.4.1)

Hi,

I'm using simple_form and active_hash, it works great. however when I set `f.association` to ActiveHash object, I met `NoMethodError - undefined method  where for #<Array:0x007f9583aa7998>:`. This is true, because ActiveHash returns Array and not AR::Relation.
This issue is almost same as https://github.com/plataformatec/simple_form/issues/966
### Version detail

```
    simple_form (3.2.1)
      actionpack (> 4, < 5.1)
      activemodel (> 4, < 5.1)
    active_hash (1.4.1)
      activesupport (>= 2.2.2)
```
### Stacktrace

```
NoMethodError - undefined method `where' for #<Array:0x007f9583aa7998>:
  simple_form (3.2.1) lib/simple_form/form_builder.rb:465:in `block in fetch_association_collection'
  simple_form (3.2.1) lib/simple_form/form_builder.rb:455:in `fetch_association_collection'
  simple_form (3.2.1) lib/simple_form/form_builder.rb:188:in `association'
   () Users/shirakawahiroyuki/.ghq/github.com/Viibar/viibar/app/views/admin/showcase/achievements/edit.html.erb:8:in `block in _app_views_admin_showcase_achievements_edit_html_erb___1571272971374673295_70140069451860'
  actionview (4.2.3) lib/action_view/helpers/capture_helper.rb:38:in `block in capture'
  actionview (4.2.3) lib/action_view/helpers/capture_helper.rb:202:in `with_output_buffer'
  actionview (4.2.3) lib/action_view/helpers/capture_helper.rb:38:in `capture'
  actionview (4.2.3) lib/action_view/helpers/form_helper.rb:444:in `form_for'
  html5_validators (1.1.2) lib/html5_validators/action_view/form_helpers.rb:23:in `form_for_with_auto_html5_validation_option'
  simple_form (3.2.1) lib/simple_form/action_view_extensions/form_helper.rb:26:in `block in simple_form_for'
  simple_form (3.2.1) lib/simple_form/action_view_extensions/form_helper.rb:45:in `with_simple_form_field_error_proc'
  simple_form (3.2.1) lib/simple_form/action_view_extensions/form_helper.rb:25:in `simple_form_for'
   () Users/shirakawahiroyuki/.ghq/github.com/Viibar/viibar/app/views/admin/showcase/achievements/edit.html.erb:3:in `_app_views_admin_showcase_achievements_edit_html_erb___1571272971374673295_70140069451860'
  actionview (4.2.3) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.3) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.3) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.3) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.3) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.3) lib/action_view/template.rb:143:in `render'
  view_source_map (0.1.0) lib/view_source_map.rb:39:in `block (2 levels) in render_template_with_path_comment'
  actionview (4.2.3) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.3) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.3) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.3) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.3) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  view_source_map (0.1.0) lib/view_source_map.rb:38:in `block in render_template_with_path_comment'
  actionview (4.2.3) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
  view_source_map (0.1.0) lib/view_source_map.rb:37:in `render_template_with_path_comment'
  actionview (4.2.3) lib/action_view/renderer/template_renderer.rb:14:in `render'
  actionview (4.2.3) lib/action_view/renderer/renderer.rb:42:in `render_template'
  actionview (4.2.3) lib/action_view/renderer/renderer.rb:23:in `render'
  actionview (4.2.3) lib/action_view/rendering.rb:100:in `_render_template'
  actionpack (4.2.3) lib/action_controller/metal/streaming.rb:217:in `_render_template'
...
```
