### PR TITLE
Add a way to specify custom collection option lookup key for i18n

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -202,6 +202,10 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   mattr_accessor :i18n_scope
   @@i18n_scope = 'simple_form'
 
+  # Where to look for translation of collection options
+  mattr_accessor :i18n_options_scope
+  @@i18n_options_scope = lambda { |i18n_scope| "#{i18n_scope}.options" }
+
   # Retrieves a given wrapper
   def self.wrapper(name)
     @@wrappers[name.to_s] or raise WrapperNotFound, "Couldn't find wrapper with name #{name}"

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -169,7 +169,7 @@ module SimpleForm
       #            email: 'E-mail.'
       #
       #  Take a look at our locale example file.
-      def translate_from_namespace(namespace, default = '')
+      def translate_from_namespace(namespace, default = '', scope = i18n_scope)
         model_names = lookup_model_names.dup
         lookups     = []
 
@@ -184,7 +184,9 @@ module SimpleForm
         lookups << :"defaults.#{reflection_or_attribute_name}"
         lookups << default
 
-        I18n.t(lookups.shift, scope: :"#{i18n_scope}.#{namespace}", default: lookups).presence
+        scope = scope ? "#{scope}." : ''
+
+        I18n.t(lookups.shift, scope: :"#{scope}#{namespace}", default: lookups).presence
       end
 
       def merge_wrapper_options(options, wrapper_options)

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -96,7 +96,9 @@ module SimpleForm
       end
 
       def translate_collection
-        if translated_collection = translate_from_namespace(:options)
+        if translated_collection = translate_from_namespace(
+          SimpleForm.i18n_options_scope.call(SimpleForm.i18n_scope), '', false
+        )
           @collection = collection.map do |key|
             html_key = "#{key}_html".to_sym
 

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -21,6 +21,40 @@ class CollectionSelectInputTest < ActionView::TestCase
     end
   end
 
+  test 'input as select uses i18n to translate select custom options' do
+    store_translations(:en, simple_form: { options: { user: { active: { yes: 'Sim', no: 'Não' } } } }) do
+      with_input_for @user, :active, :select, collection: [:yes, :no]
+      assert_select 'select option[value=yes]', 'Sim'
+      assert_select 'select option[value=no]', 'Não'
+    end
+  end
+
+  test 'input as select uses i18n options setting to translate select custom options with default scope' do
+    store_translations(
+      :en,
+      simple_form: { models: { user: { active: { yes: 'Sim', no: 'Não' } } } }
+    ) do
+      swap SimpleForm, i18n_options_scope: ->(scope) { "#{scope}.models" } do
+        with_input_for @user, :active, :select, collection: [:yes, :no]
+        assert_select 'select option[value=yes]', 'Sim'
+        assert_select 'select option[value=no]', 'Não'
+      end
+    end
+  end
+
+  test 'input as select uses i18n options setting to translate select custom options' do
+    store_translations(
+      :en,
+      values: { models: { user: { active: { yes: 'Sim', no: 'Não' } } } }
+    ) do
+      swap SimpleForm, i18n_options_scope: ->(_) { 'values.models' } do
+        with_input_for @user, :active, :select, collection: [:yes, :no]
+        assert_select 'select option[value=yes]', 'Sim'
+        assert_select 'select option[value=no]', 'Não'
+      end
+    end
+  end
+
   test 'input allows overriding collection for select types' do
     with_input_for @user, :name, :select, collection: ['Jose', 'Carlos']
     assert_select 'select.select#user_name'


### PR DESCRIPTION
A custom key can specified with `config.i18n_options_scope`:

    config.i18n_options_scope = lambda { |i18n_scope| "#{i18n_scope}.options" }

The default (above) returns `simple_form.options` - like it was always
before. But I can no easy override the `options` key like this:

    config.i18n_options_scope = lambda { |i18n_scope| "#{i18n_scope}.other" }

In addition, if I want it to be somewhere else outside the regular
`i18n_scope`, I can do:

    config.i18n_options_scope = lambda { |_| 'where.ever.i.want' }

This gives total flexibility where simple_form looks up translations of
collection options.

The current version always wants the config to be a `lambda`. One could
rewrite the implementation to work with a simple string
(`config.i18n_options_scope = 'where.ever.i.want`) if we want to give
the user total ease of defining the scope in case the scope does not
depend on the `i18n_scope`. Or the implementation could be that in case
of a single string the `i18n_scope` is automatically prepended, for
example:

    config.i18n_options_scope = 'where.ever.i.want'

... means to look up under `simple_form.where.ever.i.want`. But for
explicitness sake requiring it to be a `lambda` always might be the
better choice (but I'm open to changes).