### PR TITLE
Add `hidden_input` option to checkbox

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -55,6 +55,7 @@ module SimpleForm
       # we need the hidden field to be *outside* the label (otherwise it
       # generates invalid html - html5 only).
       def build_hidden_field_for_checkbox
+        return "" unless include_hidden?
         options = { value: unchecked_value, id: nil, disabled: input_html_options[:disabled] }
         options[:name] = input_html_options[:name] if input_html_options.has_key?(:name)
 
@@ -79,6 +80,10 @@ module SimpleForm
       # Terms of Use usually presented at most sites sign up screen.
       def required_by_default?
         false
+      end
+
+      def include_hidden?
+        options.fetch(:include_hidden, true)
       end
 
       def checked_value

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -137,6 +137,14 @@ class BooleanInputTest < ActionView::TestCase
     end
   end
 
+  test 'input with nested style allows disabling hidden field' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :active, :boolean, include_hidden: false
+      assert_select "label.boolean > input.boolean"
+      assert_no_select "input[type=hidden] + label.boolean"
+    end
+  end
+
   test 'input boolean works using :input only in wrapper config (no label_input)' do
     swap_wrapper do
       with_input_for @user, :active, :boolean


### PR DESCRIPTION
Give the possibility to skip the creation of the hidden input field
normally created along with checkox field, replicating [Rails 4.2 behavior](https://github.com/rails/rails/blob/4-2-stable/actionview/lib/action_view/helpers/tags/check_box.rb#L28)