### PR TITLE
Adds aria-invalid attribute to fields with errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,8 +982,8 @@ required attribute to force a value into an input and will prevent form submissi
 Depending on the design of the application this may or may not be desired. In many cases it can
 break existing UI's.
 
-It is possible to disable all HTML 5 extensions in **Simple Form** removing the `html5` component
-from the wrapper used to render the inputs.
+It is possible to disable all HTML 5 extensions in **Simple Form** by removing the `html5`
+component from the wrapper used to render the inputs.
 
 For example, change:
 

--- a/lib/simple_form/components/html5.rb
+++ b/lib/simple_form/components/html5.rb
@@ -11,6 +11,8 @@ module SimpleForm
         input_html_options[:required]        = has_required?
         input_html_options[:'aria-required'] = has_required? || nil
 
+        input_html_options[:'aria-invalid']  = has_errors?
+
         nil
       end
 

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -94,11 +94,34 @@ class ErrorTest < ActionView::TestCase
     assert_no_select 'span.error b', 'markup'
   end
 
-
   test 'error generates an error message with raw HTML tags' do
     with_error_for @user, :name, error_prefix: '<b>Name</b>'.html_safe
     assert_select 'span.error', "Name cannot be blank"
     assert_select 'span.error b', "Name"
+  end
+
+  test 'error adds aria-invalid attribute to inputs' do
+    with_form_for @user, :name, error: true
+    assert_select "input#user_name[name='user[name]'][aria-invalid='true']"
+
+    with_form_for @user, :name, as: :text, error: true
+    assert_select "textarea#user_name[name='user[name]'][aria-invalid='true']"
+
+    @user.errors.add(:active, 'must select one')
+    with_form_for @user, :active, as: :radio_buttons
+    assert_select "input#user_active_true[type=radio][name='user[active]'][aria-invalid='true']"
+    assert_select "input#user_active_false[type=radio][name='user[active]'][aria-invalid='true']"
+
+    with_form_for @user, :active, as: :check_boxes
+    assert_select "input#user_active_true[type=checkbox][aria-invalid='true']"
+    assert_select "input#user_active_false[type=checkbox][aria-invalid='true']"
+
+    with_form_for @user, :company_id, as: :select, error: true
+    assert_select "select#user_company_id[aria-invalid='true']"
+
+    @user.errors.add(:password, 'must not be blank')
+    with_form_for @user, :password
+    assert_select "input#user_password[type=password][aria-invalid='true']"
   end
 
   # FULL ERRORS


### PR DESCRIPTION
Adds `aria-invalid` attribute to fields with errors. 

https://www.w3.org/TR/WCAG20-TECHS/ARIA21.html
