### PR TITLE
Add support Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,6 @@ platforms :rbx do
   gem 'rubinius-developer_tools'
 end
 
-gem 'country_select', '~> 1.1.1'
+gem 'country_select', '~> 2.5.2'
 gem 'railties'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,10 +30,17 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.2)
     concurrent-ruby (1.0.2)
-    country_select (1.1.3)
+    countries (1.2.5)
+      currencies (~> 0.4.2)
+      i18n_data (~> 0.7.0)
+    country_select (2.5.2)
+      countries (~> 1.2.0)
+      sort_alphabetical (~> 1.0)
+    currencies (0.4.2)
     erubis (2.7.0)
     ffi2-generators (0.1.1)
     i18n (0.7.0)
+    i18n_data (0.7.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)
@@ -267,16 +274,19 @@ GEM
     rubysl-xmlrpc (2.0.0)
     rubysl-yaml (2.1.0)
     rubysl-zlib (2.0.1)
+    sort_alphabetical (1.0.2)
+      unicode_utils (>= 1.2.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode_utils (1.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  country_select (~> 1.1.1)
+  country_select (~> 2.5.2)
   railties
   rake
   rubinius-developer_tools

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -152,10 +152,6 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   mattr_accessor :country_priority
   @@country_priority = nil
 
-  # DEPRECATED: Maximum size allowed for inputs.
-  mattr_accessor :default_input_size
-  @@default_input_size = nil
-
   # When off, do not use translations in labels. Disabling translation in
   # hints and placeholders can be done manually in the wrapper API.
   mattr_accessor :translate_labels

--- a/lib/simple_form/components/maxlength.rb
+++ b/lib/simple_form/components/maxlength.rb
@@ -15,10 +15,7 @@ module SimpleForm
           maxlength
         else
           length_validator = find_length_validator
-
-          if length_validator && !has_tokenizer?(length_validator)
-            length_validator.options[:is] || length_validator.options[:maximum]
-          end
+          maximum_length_value_from(length_validator)
         end
       end
 
@@ -28,6 +25,22 @@ module SimpleForm
 
       def has_tokenizer?(length_validator)
         length_validator.options[:tokenizer]
+      end
+
+      # Use validation with tokenizer if version of Rails is less than 5,
+      # if not validate without the tokenizer, if version is greater than Rails 4.
+      if ActionPack::VERSION::STRING < '5'
+        def maximum_length_value_from(length_validator)
+          if length_validator && !has_tokenizer?(length_validator)
+            length_validator.options[:is] || length_validator.options[:maximum]
+          end
+        end
+      elsif ActionPack::VERSION::STRING >= '5'
+        def maximum_length_value_from(length_validator)
+          if length_validator
+            length_validator.options[:is] || length_validator.options[:maximum]
+          end
+        end
       end
     end
   end

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -6,7 +6,11 @@ class DateTimeInputWithHtml5Test < ActionView::TestCase
   test 'input generates a datetime input for datetime attributes if HTML5 compatibility is explicitly enbled' do
     with_input_for @user, :created_at, :datetime, html5: true
 
-    assert_select 'input[type|="datetime"]'
+    if ActionPack::VERSION::STRING >= '5'
+      assert_select 'input[type="datetime-local"]'
+    elsif ActionPack::VERSION::STRING < '5'
+      assert_select 'input[type="datetime"]'
+    end
   end
 
   test 'input generates a datetime select for datetime attributes' do
@@ -76,7 +80,11 @@ class DateTimeInputWithoutHtml5Test < ActionView::TestCase
     swap_wrapper do
       with_input_for @user, :created_at, :datetime, html5: true
 
-      assert_select 'input[type|="datetime"]'
+      if ActionPack::VERSION::STRING >= '5'
+        assert_select 'input[type="datetime-local"]'
+      elsif ActionPack::VERSION::STRING < '5'
+        assert_select 'input[type="datetime"]'
+      end
     end
   end
 

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -14,6 +14,7 @@ class DiscoveryTest < ActionView::TestCase
         Object.send :remove_const, :CustomizedInput
         Object.send :remove_const, :DeprecatedInput
         Object.send :remove_const, :CollectionSelectInput
+        CustomInputs.send :remove_const, :CustomizedInput
         CustomInputs.send :remove_const, :PasswordInput
         CustomInputs.send :remove_const, :NumericInput
       end

--- a/test/inputs/priority_input_test.rb
+++ b/test/inputs/priority_input_test.rb
@@ -5,14 +5,22 @@ class PriorityInputTest < ActionView::TestCase
   test 'input generates a country select field' do
     with_input_for @user, :country, :country
     assert_select 'select#user_country'
-    assert_select 'select option[value=Brazil]', 'Brazil'
+    if ActionPack::VERSION::STRING >= '5'
+      assert_select 'select option[value=BR]', 'Brazil'
+    elsif ActionPack::VERSION::STRING < '5'
+      assert_select 'select option[value=Brazil]', 'Brazil'
+    end
     assert_no_select 'select option[value=""][disabled=disabled]'
   end
 
   test 'input generates a country select with SimpleForm default' do
     swap SimpleForm, country_priority: [ 'Brazil' ] do
       with_input_for @user, :country, :country
-      assert_select 'select option[value=""][disabled=disabled]'
+      if ActionPack::VERSION::STRING >= '5'
+        assert_select 'select option[value="---------------"][disabled=disabled]'
+      elsif ActionPack::VERSION::STRING < '5'
+        assert_select 'select option[value=""][disabled=disabled]'
+      end
     end
   end
 

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -32,9 +32,11 @@ class StringInputTest < ActionView::TestCase
     assert_select 'input.string[maxlength="25"]'
   end
 
-  test 'input does not get maxlength from validation when tokenizer present' do
-    with_input_for @validating_user, :action, :string
-    assert_no_select 'input.string[maxlength]'
+  if ActionPack::VERSION::STRING < '5'
+    test 'input does not get maxlength from validation when tokenizer present' do
+      with_input_for @validating_user, :action, :string
+      assert_no_select 'input.string[maxlength]'
+    end
   end
 
   test 'input gets maxlength from validation when :is option present' do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -215,7 +215,9 @@ class ValidatingUser < User
     only_integer: true
   validates_length_of :name, maximum: 25
   validates_length_of :description, maximum: 50
-  validates_length_of :action, maximum: 10, tokenizer: lambda { |str| str.scan(/\w+/) }
+  if ActionPack::VERSION::STRING < '5'
+    validates_length_of :action, maximum: 10, tokenizer: lambda { |str| str.scan(/\w+/) }
+  end
   validates_length_of :home_picture, is: 12
 
   def min_amount


### PR DESCRIPTION
Enhancements
  * Support to Rails `5.0.x` Stable.

Unreleased
  * Removed deprecated methods `default_input_size`.