### PR TITLE
Make sure that builder is set.

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -38,6 +38,7 @@ module SimpleForm
 
     def initialize(*) #:nodoc:
       super
+      options[:builder] ||= self.class
       @defaults = options[:defaults]
       @wrapper  = SimpleForm.wrapper(options[:wrapper] || SimpleForm.default_wrapper)
     end

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -566,6 +566,13 @@ class BuilderTest < ActionView::TestCase
     end
   end
 
+  test 'fields for inherits the form builder class' do
+    form = SimpleForm::FormBuilder.new "user", @user, self, {}
+    form.fields_for :company, Company.new do |company|
+      assert company.instance_of?(SimpleForm::FormBuilder)
+    end
+  end
+
   test "fields for with a hash like model yeilds an instance of FormBuilder" do
     with_concat_form_for(:user) do |f|
       f.simple_fields_for(:author, HashBackedAuthor.new) do |author|


### PR DESCRIPTION
When instantiating a simple form for other ways that simple_form_for will
not set the builder correctly. This makes sure that the builder option is
always set.

I found this while testing a partial that receives a form builder instance, I've created that with `SimpleForm::FormBuilder.new`, but it behave a little bit different as the fields_for does not inherit the builder.
