### PR TITLE
Use Rails 5 Attributes API for decimal_or_float?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4-0-stable
   - gemfiles/Gemfile.rails-4-1-stable
   - gemfiles/Gemfile.rails-4-2-stable
+  - gemfiles/Gemfile.rails-5-0-stable
   - Gemfile
 matrix:
   allow_failures:

--- a/gemfiles/Gemfile.rails-5-0-stable
+++ b/gemfiles/Gemfile.rails-5-0-stable
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
+gem 'country_select', '~> 1.1.1'
+gem 'railties', github: 'rails/rails', branch: '5-0-stable'
+gem 'activemodel', github: 'rails/rails', branch: '5-0-stable'
+gem 'actionpack', github: 'rails/rails', branch: '5-0-stable'
+gem 'rake'
+gem 'tzinfo'

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -115,7 +115,7 @@ module SimpleForm
       end
 
       def decimal_or_float?
-        column.number? && column.type != :integer
+        column.type == :float || column.type == :decimal
       end
 
       def nested_boolean_style?

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,10 +1,6 @@
 Association = Struct.new(:klass, :name, :macro, :scope, :options)
 
 Column = Struct.new(:name, :type, :limit) do
-  # Returns +true+ if the column is either of type integer, float or decimal.
-  def number?
-    type == :integer || type == :float || type == :decimal
-  end
 end
 
 Relation = Struct.new(:records) do


### PR DESCRIPTION
The motivation for this commit originated in #1342.

@rafaelfranca mentioned that we should be using the new `type_for_attribute` interface
to determine the precise type of a column instead. At first I used the interface directly like
this:

```ruby
      def decimal_or_float?
        if object.respond_to?(:type_for_attribute)
          type = object.type_for_attribute(column.name.to_s).type
          type == :float || :decimal
        else
          column.number? && column.type != :integer
        end
      end
```

I then realized that we're already asking the column object directly for the type, so
why not simple check for the two types we care about and implement the method in a much
more straightforward *and* backward-compatible way? I ended up with this:

```ruby
      def decimal_or_float?
        column.type == :float || :decimal
      end
```

I could be missing something obvious but this is green in my Rails 5.0.0 app. The only
remaining issue I see is how the simple_form specs mock out the now removed number?
ActiveModel method: https://github.com/plataformatec/simple_form/blob/1c389f65594db90a1244d93a00a388b4aea4bcc6/test/support/models.rb#L3-L8

I'm gonna have to remove that most likely.

/cc @lucasmazza 