### PR TITLE
only include ActionViewExtensions when ActionView is loaded

### DIFF
--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -30,6 +30,8 @@ module SimpleForm
   end
 end
 
-ActiveSupport.on_load(:action_view) do
-  ActionView::Helpers::FormBuilder.send :include, SimpleForm::ActionViewExtensions::Builder
+module ActionView::Helpers
+  class FormBuilder
+    include SimpleForm::ActionViewExtensions::Builder
+  end
 end

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -30,8 +30,6 @@ module SimpleForm
   end
 end
 
-module ActionView::Helpers
-  class FormBuilder
-    include SimpleForm::ActionViewExtensions::Builder
-  end
+ActiveSupport.on_load(:action_view) do
+  ActionView::Helpers::FormBuilder.send :include, SimpleForm::ActionViewExtensions::Builder
 end

--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -66,4 +66,6 @@ module SimpleForm
   end
 end
 
-ActionView::Base.send :include, SimpleForm::ActionViewExtensions::FormHelper
+ActiveSupport.on_load(:action_view) do
+  include SimpleForm::ActionViewExtensions::FormHelper
+end


### PR DESCRIPTION
this resolves a load order issue which I encountered when testing with rspec.

Also, the same problem occurred with https://github.com/bootstrap-ruby/rails-bootstrap-forms, which I solved in a similar manner in https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/275