### PR TITLE
Ignore the `:label_text` when rendering `label` tags.

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -299,7 +299,7 @@ module SimpleForm
       return super if args.first.is_a?(String) || block_given?
 
       options = args.extract_options!.dup
-      options[:label_html] = options.except(:label, :required, :as)
+      options[:label_html] = options.except(:label, :label_text, :required, :as)
 
       column      = find_attribute_column(attribute_name)
       input_type  = default_input_type(attribute_name, column, options)

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -120,4 +120,11 @@ class LabelTest < ActionView::TestCase
       assert_select 'label[for=user_time_zone]', 'Time Zone:'
     end
   end
+
+  test 'builder allows label specific `label_text` option' do
+    with_label_for @user, :time_zone, label_text: lambda { |l, _, _| "#{l.titleize}:" }
+
+    assert_no_select 'label[label_text]'
+    assert_select 'label[for=user_time_zone]', 'Time Zone:'
+  end
 end


### PR DESCRIPTION
Closes #1314.