### PR TITLE
Do not ignore implicitly passed required option

### DIFF
--- a/lib/simple_form/components/html5.rb
+++ b/lib/simple_form/components/html5.rb
@@ -8,8 +8,8 @@ module SimpleForm
       def html5(wrapper_options = nil)
         @html5 = true
 
-        input_html_options[:required]        = has_required?
-        input_html_options[:'aria-required'] = has_required? || nil
+        input_html_options[:required]        = input_html_required_option
+        input_html_options[:'aria-required'] = input_html_aria_required_option
 
         input_html_options[:'aria-invalid']  = has_errors? || nil
 
@@ -18,6 +18,14 @@ module SimpleForm
 
       def html5?
         @html5
+      end
+
+      def input_html_required_option
+        !options[:required].nil? ? required_field? : has_required?
+      end
+
+      def input_html_aria_required_option
+        !options[:required].nil? ? (required_field? || nil) : (has_required? || nil)
       end
 
       def has_required?

--- a/test/inputs/required_test.rb
+++ b/test/inputs/required_test.rb
@@ -34,6 +34,38 @@ class RequiredTest < ActionView::TestCase
       with_input_for @user, :name, :string
       assert_select 'input[type=text].required'
       assert_no_select 'input[type=text][required]'
+      assert_no_select 'input[type=text][aria-required]'
+    end
+  end
+
+  test 'when not using browser validations, when required option is set to false, input does not generate required html attribute' do
+    swap SimpleForm, browser_validations: false do
+      with_input_for @user, :name, :string, required: false
+      assert_no_select 'input[type=text].required'
+      assert_no_select 'input[type=text][required]'
+      assert_no_select 'input[type=text][aria-required]'
+    end
+  end
+
+  test 'when not using browser validations, when required option is set to true, input generates required html attribute' do
+    swap SimpleForm, browser_validations: false do
+      with_input_for @user, :name, :string, required: true
+      assert_select 'input[type=text].required'
+      assert_select 'input[type=text][required]'
+      assert_select 'input[type=text][aria-required]'
+    end
+  end
+
+  test 'when not using browser validations, when required option is true in the wrapper, input does not generate required html attribute' do
+    swap SimpleForm, browser_validations: false do
+      swap_wrapper :default, self.custom_wrapper_with_required_input do
+        with_concat_form_for(@user) do |f|
+          concat f.input :name
+        end
+        assert_select 'input[type=text].required'
+        assert_no_select 'input[type=text][required]'
+        assert_no_select 'input[type=text][aria-required]'
+      end
     end
   end
 


### PR DESCRIPTION
Addresses https://github.com/plataformatec/simple_form/issues/1380

Confirmed that it was caused by https://github.com/plataformatec/simple_form/commit/a280ba770f2cbfa88b05e26cf83247d5b6900139. The breaking change was that it started to override the required option with `false` whenever `SimpleForm.browser_validations` was false.

Happy to add a spec if you agree with the approach 😄 

