### PR TITLE
Support the ActiveModel::Type API when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4-0-stable
   - gemfiles/Gemfile.rails-4-1-stable
   - gemfiles/Gemfile.rails-4-2-stable
+  - gemfiles/Gemfile.rails-5-0-stable
   - Gemfile
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ matrix:
       gemfile: Gemfile
     - rvm: jruby
       gemfile: Gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-5-0-stable
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-5-0-stable
+    - rvm: 2.1.5
+      gemfile: gemfiles/Gemfile.rails-5-0-stable
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-5-0-stable
 notifications:
   email: false
   slack:

--- a/gemfiles/Gemfile.rails-5-0-stable
+++ b/gemfiles/Gemfile.rails-5-0-stable
@@ -1,0 +1,15 @@
+source 'https://rubygems.org'
+
+gemspec :path => '..'
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
+gem 'country_select', '~> 1.1.1'
+gem 'railties', github: 'rails/rails', branch: '5-0-stable'
+gem 'activemodel', github: 'rails/rails', branch: '5-0-stable'
+gem 'actionpack', github: 'rails/rails', branch: '5-0-stable'
+gem 'rake'
+gem 'tzinfo'

--- a/gemfiles/Gemfile.rails-5-0-stable
+++ b/gemfiles/Gemfile.rails-5-0-stable
@@ -7,7 +7,7 @@ platforms :rbx do
   gem 'rubinius-developer_tools'
 end
 
-gem 'country_select', '~> 1.1.1'
+gem 'country_select', '~> 2.5.2'
 gem 'railties', github: 'rails/rails', branch: '5-0-stable'
 gem 'activemodel', github: 'rails/rails', branch: '5-0-stable'
 gem 'actionpack', github: 'rails/rails', branch: '5-0-stable'

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -549,7 +549,9 @@ module SimpleForm
     end
 
     def find_attribute_column(attribute_name)
-      if @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
+      if @object.respond_to?(:type_for_attribute) && @object.has_attribute?(attribute_name)
+        @object.type_for_attribute(attribute_name)
+      elsif @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
         @object.column_for_attribute(attribute_name)
       end
     end

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -115,7 +115,7 @@ module SimpleForm
       end
 
       def decimal_or_float?
-        column.number? && column.type != :integer
+        column.type == :float || column.type == :decimal
       end
 
       def nested_boolean_style?

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -139,7 +139,11 @@ class FormBuilderTest < ActionView::TestCase
 
   test 'builder generates uuid fields for uuid columns' do
     with_form_for @user, :uuid
-    assert_select 'form input#user_uuid.string.uuid'
+    if defined? ActiveModel::Type
+      assert_select 'form input#user_uuid.string.string'
+    else
+      assert_select 'form input#user_uuid.string.uuid'
+    end
   end
 
   test 'builder generates password fields for columns that matches password' do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,10 +1,6 @@
 Association = Struct.new(:klass, :name, :macro, :scope, :options)
 
 Column = Struct.new(:name, :type, :limit) do
-  # Returns +true+ if the column is either of type integer, float or decimal.
-  def number?
-    type == :integer || type == :float || type == :decimal
-  end
 end
 
 Relation = Struct.new(:records) do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -126,6 +126,33 @@ class User
     Column.new(attribute, column_type, limit)
   end
 
+  begin
+    require 'active_model/type'
+    def type_for_attribute(attribute)
+      column_type, limit = case attribute.to_sym
+        when :name, :status, :password then [:string, 100]
+        when :description   then [:text, 200]
+        when :age           then :integer
+        when :credit_limit  then [:decimal, 15]
+        when :active        then :boolean
+        when :born_at       then :date
+        when :delivery_time then :time
+        when :created_at    then :datetime
+        when :updated_at    then :datetime
+        when :lock_version  then :integer
+        when :home_picture  then :string
+        when :amount        then :integer
+        when :attempts      then :integer
+        when :action        then :string
+        when :credit_card   then :string
+        when :uuid          then :string
+      end
+
+      ActiveModel::Type.lookup(column_type, limit: limit)
+    end
+  rescue LoadError
+  end
+
   def has_attribute?(attribute)
     case attribute.to_sym
       when :name, :status, :password, :description, :age,


### PR DESCRIPTION
Another take to fix #1342, building on top of #1398.

We now favour the `ActiveModel::Type` API when available (Rails 5+), and still support the column objects from earlier versions. Our test models now implement the `type_for_attribute` API, but I discussed once with @rafaelfranca about adding an end to end test case based on ActiveRecord (+ sqlite) to provide better feedback on this integration.