### PR TITLE
specify :boolean_label_class on a per-input basis

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -6,7 +6,7 @@ module SimpleForm
 
         if nested_boolean_style?
           build_hidden_field_for_checkbox +
-            template.label_tag(nil, class: SimpleForm.boolean_label_class) {
+            template.label_tag(nil, class: boolean_label_class) {
               build_check_box_without_hidden_field(merged_input_options) +
                 inline_label
             }
@@ -21,7 +21,7 @@ module SimpleForm
         elsif nested_boolean_style?
           html_options = label_html_options.dup
           html_options[:class] ||= []
-          html_options[:class].push(SimpleForm.boolean_label_class) if SimpleForm.boolean_label_class
+          html_options[:class].push(boolean_label_class) if boolean_label_class
 
           merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 
@@ -35,6 +35,10 @@ module SimpleForm
       end
 
       private
+
+      def boolean_label_class
+        options[:boolean_label_class] || SimpleForm.boolean_label_class
+      end
 
       # Build a checkbox tag using default unchecked value. This allows us to
       # reuse the method for nested boolean style, but with no unchecked value,

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -164,6 +164,16 @@ class BooleanInputTest < ActionView::TestCase
     end
   end
 
+  test 'input boolean allows specifying boolean_label_class on a per-input basis' do
+    swap_wrapper do
+      swap SimpleForm, boolean_style: :nested, boolean_label_class: 'foo' do
+        with_input_for @user, :active, :boolean, boolean_label_class: 'baz'
+
+        assert_select 'label.boolean + input[type=hidden] + label.baz > input.boolean'
+      end
+    end
+  end
+
   test 'input boolean with nested style works using :input only in wrapper config (no label_input), adding the extra label wrapper with custom class' do
     swap_wrapper do
       swap SimpleForm, boolean_style: :nested, boolean_label_class: 'foo' do


### PR DESCRIPTION
At my job, we need to generate boolean checkboxes with different label classes, like so:

``` html
<label class='control'>
  <input type='checkbox'>
  Regular checkbox
</label>

<label class='control small'>
  <input type='checkbox'>
  Small checkbox
</label>
```

The `boolean_label_class` global option was added in #999, but this PR adds the ability to specify the `:boolean_label_class` on a per-input basis.
