### PR TITLE
Ensure the arg sent to `type_for_attribute` is a string

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -550,7 +550,7 @@ module SimpleForm
 
     def find_attribute_column(attribute_name)
       if @object.respond_to?(:type_for_attribute) && @object.has_attribute?(attribute_name)
-        @object.type_for_attribute(attribute_name)
+        @object.type_for_attribute(attribute_name.to_s)
       elsif @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
         @object.column_for_attribute(attribute_name)
       end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -129,23 +129,23 @@ class User
   begin
     require 'active_model/type'
     def type_for_attribute(attribute)
-      column_type, limit = case attribute.to_sym
-        when :name, :status, :password then [:string, 100]
-        when :description   then [:text, 200]
-        when :age           then :integer
-        when :credit_limit  then [:decimal, 15]
-        when :active        then :boolean
-        when :born_at       then :date
-        when :delivery_time then :time
-        when :created_at    then :datetime
-        when :updated_at    then :datetime
-        when :lock_version  then :integer
-        when :home_picture  then :string
-        when :amount        then :integer
-        when :attempts      then :integer
-        when :action        then :string
-        when :credit_card   then :string
-        when :uuid          then :string
+      column_type, limit = case attribute
+        when 'name', 'status', 'password' then [:string, 100]
+        when 'description'   then [:text, 200]
+        when 'age'           then :integer
+        when 'credit_limit'  then [:decimal, 15]
+        when 'active'        then :boolean
+        when 'born_at'       then :date
+        when 'delivery_time' then :time
+        when 'created_at'    then :datetime
+        when 'updated_at'    then :datetime
+        when 'lock_version'  then :integer
+        when 'home_picture'  then :string
+        when 'amount'        then :integer
+        when 'attempts'      then :integer
+        when 'action'        then :string
+        when 'credit_card'   then :string
+        when 'uuid'          then :string
       end
 
       ActiveModel::Type.lookup(column_type, limit: limit)


### PR DESCRIPTION
Per the docs, it is required to be a string:
http://api.rubyonrails.org/v5.0.0/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-type_for_attribute

If you send a symbol, you will get an empty
ActiveRecord::Type::Value instance instead of the actual
column type you might have expected.

Since `f.input [attr]` can otherwise be invoked with
either a symbol or string, it seems important to
support both.

Fixes #1421