### PR TITLE
Add sanitized_options for collection check_boxes and radio_buttons

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -1,6 +1,7 @@
 require 'action_view'
 require 'simple_form/action_view_extensions/form_helper'
 require 'simple_form/action_view_extensions/builder'
+require 'simple_form/action_view_extensions/tags'
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/hash/except'
 require 'active_support/core_ext/hash/reverse_merge'

--- a/lib/simple_form/action_view_extensions/tags.rb
+++ b/lib/simple_form/action_view_extensions/tags.rb
@@ -1,0 +1,30 @@
+module ActionView
+  module Helpers
+    module Tags
+      class Base
+        def add_default_name_and_id_for_value(tag_value, options)
+          if tag_value.nil?
+            add_default_name_and_id(options)
+          else
+            specified_id = options["id"]
+            add_default_name_and_id(options)
+
+            if specified_id.blank? && options["id"].present?
+              tag_value = options[:sanitized_value] || tag_value
+
+              options["id"] += "_#{sanitized_value(tag_value)}"
+            end
+          end
+
+          options.delete('sanitized_value')
+        end
+
+        def sanitized_value(value)
+          value = @options[:sanitized_value] || value
+
+          value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+        end
+      end
+    end
+  end
+end

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -7,22 +7,36 @@ module SimpleForm
         item_wrapper_tag   = @options.fetch(:item_wrapper_tag, :span)
         item_wrapper_class = @options[:item_wrapper_class]
 
-        @collection.map do |item|
+        validate_sanitized_values_option
+
+        @collection.each_with_index.map do |item, idx|
           value = value_for_collection(item, @value_method)
           text  = value_for_collection(item, @text_method)
+          sanitized_value = @options[:sanitized_values] ? @options[:sanitized_values][idx] : nil 
+
           default_html_options = default_html_options_for_collection(item, value)
           additional_html_options = option_html_attributes(item)
+          sanitized_value_options = sanitized_value ? { sanitized_value: sanitized_value } : {}
+          combined_options = default_html_options.merge(additional_html_options).merge(sanitized_value_options)
 
-          rendered_item = yield item, value, text, default_html_options.merge(additional_html_options)
+          rendered_item = yield item, value, text, combined_options
 
           if @options.fetch(:boolean_style, SimpleForm.boolean_style) == :nested
             label_options = default_html_options.slice(:index, :namespace)
             label_options['class'] = @options[:item_label_class]
-            rendered_item = @template_object.label(@object_name, sanitize_attribute_name(value), rendered_item, label_options)
+            attr_value = sanitized_value || value
+            rendered_item = @template_object.label(@object_name, sanitize_attribute_name(attr_value), rendered_item, label_options)
           end
 
           item_wrapper_tag ? @template_object.content_tag(item_wrapper_tag, rendered_item, class: item_wrapper_class) : rendered_item
         end.join.html_safe
+      end
+
+      def validate_sanitized_values_option
+        return unless @options[:sanitized_values]
+        return unless @options[:sanitized_values].length != @collection.length
+
+        raise ArgumentError, ":sanitized_valutes must be an array of same length as :collection"
       end
 
       def wrap_rendered_collection(collection)

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -300,4 +300,39 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'input check boxes, when sanitized_values option is passed, have the correct id attributes generated from these values' do
+    with_input_for @user, :gender, :check_boxes, collection: ['мужской', 'женский'], sanitized_values: [:male, :female]
+
+    assert_select 'input[id=user_gender_male]'
+    assert_select 'input[id=user_gender_female]'
+    assert_no_select 'input[sanitized_value]'
+  end
+
+  test 'input check boxes with nested style, when sanitized_values option is passed, have the correct id attributes generated from these values' do
+    with_input_for @user, :gender, :check_boxes, collection: ['мужской', 'женский'],
+                          sanitized_values: [:male, :female], boolean_style: :nested
+
+    assert_select 'input[id=user_gender_male]'
+    assert_select 'input[id=user_gender_female]'
+    assert_no_select 'input[sanitized_value]'
+  end
+
+  test 'input check boxes with nested style, when sanitized_values option is passed, have the correct for attributes generated from these values' do
+    with_input_for @user, :gender, :check_boxes, collection: ['мужской', 'женский'],
+                          sanitized_values: [:male, :female], boolean_style: :nested
+
+    assert_select 'label[for=user_gender_male]'
+    assert_select 'label[for=user_gender_female]'
+  end
+
+  test 'input check boxes, when sanitized_values length is not equal to collection length, raises error' do
+    assert_raise ArgumentError do
+      with_input_for @user, :gender, :check_boxes, collection: ['мужской', 'женский'], sanitized_values: [:male, :female, :other]
+    end
+
+    assert_raise ArgumentError do
+      with_input_for @user, :gender, :check_boxes, collection: ['мужской', 'женский'], sanitized_values: [:male]
+    end
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -423,4 +423,39 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'input radio, when sanitized_values option is passed, have the correct id attributes generated from these values' do
+    with_input_for @user, :gender, :radio_buttons, collection: ['мужской', 'женский'], sanitized_values: [:male, :female]
+
+    assert_select 'input[id=user_gender_male]'
+    assert_select 'input[id=user_gender_female]'
+    assert_no_select 'input[sanitized_value]'
+  end
+
+  test 'input radio with nested style, when sanitized_values option is passed, have the correct id attributes generated from these values' do
+    with_input_for @user, :gender, :radio_buttons, collection: ['мужской', 'женский'],
+                          sanitized_values: [:male, :female], boolean_style: :nested
+
+    assert_select 'input[id=user_gender_male]'
+    assert_select 'input[id=user_gender_female]'
+    assert_no_select 'input[sanitized_value]'
+  end
+
+  test 'input radio with nested style, when sanitized_values option is passed, have the correct for attributes generated from these values' do
+    with_input_for @user, :gender, :radio_buttons, collection: ['мужской', 'женский'],
+                          sanitized_values: [:male, :female], boolean_style: :nested
+
+    assert_select 'label[for=user_gender_male]'
+    assert_select 'label[for=user_gender_female]'
+  end
+
+  test 'input radio, when sanitized_values length is not equal to collection length, raises error' do
+    assert_raise ArgumentError do
+      with_input_for @user, :gender, :radio_buttons, collection: ['мужской', 'женский'], sanitized_values: [:male, :female, :other]
+    end
+
+    assert_raise ArgumentError do
+      with_input_for @user, :gender, :radio_buttons, collection: ['мужской', 'женский'], sanitized_values: [:male]
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to address a pain point for some users that try to use `check_boxes` or `radio_buttons` with `collection` array that contains non-latin characters. (https://github.com/plataformatec/simple_form/issues/1347 and  https://github.com/plataformatec/simple_form/issues/1350). The current code filters values through a latin regex (`/[^-\w]/`), and generates `id` and `for` attributes after that. This results in inaccurate values and broken functionality (cannot check checkbox by clicking on its label).

Here is a repo with working examples: https://github.com/petrgazarov/simple_form_check_boxes

Thanks for your work with simple_form btw, I'm a big fan and prefer it to vanilla forms every time!
