### PR TITLE
silent deprication warning for placeholder_text

### DIFF
--- a/lib/simple_form/components/placeholders.rb
+++ b/lib/simple_form/components/placeholders.rb
@@ -7,7 +7,7 @@ module SimpleForm
         nil
       end
 
-      def placeholder_text
+      def placeholder_text(wrapper_options = nil)
         placeholder = options[:placeholder]
         placeholder.is_a?(String) ? placeholder : translate_from_namespace(:placeholders)
       end


### PR DESCRIPTION
Similar to https://github.com/plataformatec/simple_form/pull/1086.
If we are using `placeholder_text` in custom wrapper within label tag it will cause deprecation warning. i.e:

``` [ruby]
config.wrappers :custom_wrapper, tag: "div", class: "form-group horizontal-group" do |b|
  b.wrapper tag: "label", class: "col-sm-8 btn btn-default" do |lb|
    lb.use :placeholder_text
    lb.use :input, class: "hidden"
  end
end
```

This is fix for deprecation warning.
