### PR TITLE
Add bin/spring before rails to not hungs

### DIFF
--- a/lib/simple_form/railtie.rb
+++ b/lib/simple_form/railtie.rb
@@ -7,7 +7,7 @@ module SimpleForm
     config.after_initialize do
       unless SimpleForm.configured?
         warn '[Simple Form] Simple Form is not configured in the application and will use the default values.' +
-          ' Use `rails generate simple_form:install` to generate the Simple Form configuration.'
+          ' Use `bin/spring rails generate simple_form:install` to generate the Simple Form configuration.'
       end
     end
   end


### PR DESCRIPTION
Running `rails generate simple_form:install` hungs because of spring.