### PR TITLE
remove Fixnum and Bignum deprecated warning

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -90,9 +90,17 @@ module SimpleForm
       end
 
       def collection_includes_basic_objects?(collection_classes)
-        (collection_classes & [
-          String, Integer, Fixnum, Bignum, Float, NilClass, Symbol, TrueClass, FalseClass
-        ]).any?
+        basic_objects = if unified_intger_version?
+          [String, Integer, Float, NilClass, Symbol, TrueClass, FalseClass]
+        else
+          [String, Integer, Fixnum, Bignum, Float, NilClass, Symbol, TrueClass, FalseClass]
+        end
+
+        (collection_classes & basic_objects).any?
+      end
+
+      def unified_intger_version?
+        0.class == Integer
       end
 
       def translate_collection

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -90,11 +90,8 @@ module SimpleForm
       end
 
       def collection_includes_basic_objects?(collection_classes)
-        basic_objects = if unified_intger_version?
-          [String, Integer, Float, NilClass, Symbol, TrueClass, FalseClass]
-        else
-          [String, Integer, Fixnum, Bignum, Float, NilClass, Symbol, TrueClass, FalseClass]
-        end
+        basic_objects =  [String, Integer, Float, NilClass, Symbol, TrueClass, FalseClass]
+        basic_objects += [Fixnum, Bignum] unless unified_intger_version? # Ruby <= 2.3.x compatibility
 
         (collection_classes & basic_objects).any?
       end


### PR DESCRIPTION
Fixnum and Bignum is deprecated at Ruby2.4.

https://github.com/ruby/ruby/blob/v2_4_0/NEWS#L288