### PR TITLE
[TASK] Drop support for Ruby 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5
   - 2.2.4
@@ -19,8 +18,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 1.9.3
-      gemfile: Gemfile
     - rvm: 2.0.0
       gemfile: Gemfile
     - rvm: 2.1.5


### PR DESCRIPTION
Ruby 1.9.3 was end-of-lifed on 2015-02-23.