### PR TITLE
Exclude hidden field when unchecked_value: false

### DIFF
--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -60,7 +60,7 @@ module SimpleForm
       # we need the hidden field to be *outside* the label (otherwise it
       # generates invalid html - html5 only).
       def build_hidden_field_for_checkbox
-        return "" unless include_hidden?
+        return "" if !include_hidden? || !unchecked_value
         options = { value: unchecked_value, id: nil, disabled: input_html_options[:disabled] }
         options[:name] = input_html_options[:name] if input_html_options.has_key?(:name)
 

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -146,6 +146,14 @@ class BooleanInputTest < ActionView::TestCase
     end
   end
 
+  test 'input with nested style does not include hidden field when unchecked_value is false' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :active, :boolean, unchecked_value: false
+      assert_select "label.boolean > input.boolean"
+      assert_no_select "input[type=hidden] + label.boolean"
+    end
+  end
+
   test 'input boolean works using :input only in wrapper config (no label_input)' do
     swap_wrapper do
       with_input_for @user, :active, :boolean


### PR DESCRIPTION
Rails does not generate a hidden field for checkboxes if
`unchecked_value` is false. The nested boolean creates its own hidden
field and ignores this rule from rails. That means that the hidden
field is generated for a falsey value when using the nested style, but
not when using the inline style.

This commit fixes this problem by making the nested style behave like
the inline style, adhering to the standard set by rails.

Resolves: #1320

Note that this may cause problem for people relying in this faulty behavior. But I think it's a good idea to fix this inconsistency in the long run.