### PR TITLE
Guess input type more carefully

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -552,12 +552,12 @@ module SimpleForm
         :datetime
       when :string, :citext, nil
         case attribute_name.to_s
-        when /\bpassword\b/  then :password
-        when /\btime_zone\b/ then :time_zone
-        when /\bcountry\b/   then :country
-        when /\bemail\b/     then :email
-        when /\bphone\b/     then :tel
-        when /\burl\b/       then :url
+        when /(?:\b|\W|_)password(?:\b|\W|_)/  then :password
+        when /(?:\b|\W|_)time_zone(?:\b|\W|_)/ then :time_zone
+        when /(?:\b|\W|_)country(?:\b|\W|_)/   then :country
+        when /(?:\b|\W|_)email(?:\b|\W|_)/     then :email
+        when /(?:\b|\W|_)phone(?:\b|\W|_)/     then :tel
+        when /(?:\b|\W|_)url(?:\b|\W|_)/       then :url
         else
           file_method?(attribute_name) ? :file : (input_type || :string)
         end

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -552,12 +552,12 @@ module SimpleForm
         :datetime
       when :string, :citext, nil
         case attribute_name.to_s
-        when /password/  then :password
-        when /time_zone/ then :time_zone
-        when /country/   then :country
-        when /email/     then :email
-        when /phone/     then :tel
-        when /url/       then :url
+        when /\bpassword\b/  then :password
+        when /\btime_zone\b/ then :time_zone
+        when /\bcountry\b/   then :country
+        when /\bemail\b/     then :email
+        when /\bphone\b/     then :tel
+        when /\burl\b/       then :url
         else
           file_method?(attribute_name) ? :file : (input_type || :string)
         end

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -271,6 +271,11 @@ class FormBuilderTest < ActionView::TestCase
     assert_select 'form select#user_age.select'
   end
 
+  test 'builder does not generate url fields for columns that contain only the letters url' do
+    with_form_for @user, :hourly
+    assert_no_select 'form input#user_url.string.url'
+  end
+
   test 'builder allows overriding default input type for text' do
     with_form_for @user, :name, as: :text
     assert_no_select 'form input#user_name'

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -274,6 +274,7 @@ class FormBuilderTest < ActionView::TestCase
   test 'builder does not generate url fields for columns that contain only the letters url' do
     with_form_for @user, :hourly
     assert_no_select 'form input#user_url.string.url'
+    assert_select 'form input#user_hourly.string'
   end
 
   test 'builder allows overriding default input type for text' do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -91,7 +91,7 @@ class User
     :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :gender,
     :extra_special_company_id, :pictures, :picture_ids, :special_pictures,
     :special_picture_ids, :uuid, :friends, :friend_ids, :special_tags, :special_tag_ids,
-    :citext, :hstore, :json, :jsonb
+    :citext, :hstore, :json, :jsonb, :hourly
 
   def self.build(extra_attributes = {})
     attributes = {


### PR DESCRIPTION
Match on word boundaries only.

The word "hourly" triggers a url type validation, that's not great.