### PR TITLE
require 'action_pack' before using it

### DIFF
--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -1,4 +1,5 @@
 require 'action_view'
+require 'action_pack'
 require 'simple_form/action_view_extensions/form_helper'
 require 'simple_form/action_view_extensions/builder'
 require 'active_support/core_ext/hash/slice'


### PR DESCRIPTION
Hello, 

This PR should fix #1498. 

Usually you will have required `action_pack` before using `simple_form`, but sometimes that hasn't happened yet.

Please check it out and let me know what you think.

Thanks! 