### PR TITLE
added merge_classes method for wrappers

### DIFF
--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -57,7 +57,8 @@ module SimpleForm
 
         klass = html_classes(input, options)
         opts  = html_options(options)
-        opts[:class] = (klass << opts[:class]).join(' ').strip unless klass.empty?
+        merge_classes(klass, opts[:class])
+        opts[:class] = klass.join(' ').strip unless klass.empty?
         input.template.content_tag(tag, content, opts)
       end
 
@@ -67,6 +68,16 @@ module SimpleForm
 
       def html_classes(input, options)
         @defaults[:class].dup
+      end
+      
+      def merge_classes(klass, klass2)
+        klass << klass2 unless klass2.blank?
+        #['col-xs-\d+', 'col-sm-\d+', 'col-md-\d+', 'col-lg-\d+'].each do |bc|
+        #  matches = klass.grep(Regexp.new(bc))
+        #  matches[0...(matches.size-1)].each do |match|
+        #    klass.delete(match)
+        #  end
+        #end
       end
     end
   end


### PR DESCRIPTION
Hi guys and thanks for the fantastic library.
This is a proposal to add a `merge_classes` method for wrappers. I needed a better way of overriding wrapper bootstrap grid class, hence I came up with this. I have left in (but commented out) the full bootstrap specific code, that I'm using (I guess that needs to go away since simple_form supports multiple frameworks). Anyway having a method would make it easy to monkey patch how classes are merged.