### PR TITLE
Add frozen_string_literal magic comment to several files

### DIFF
--- a/lib/generators/simple_form/install_generator.rb
+++ b/lib/generators/simple_form/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Generators
     class InstallGenerator < Rails::Generators::Base

--- a/lib/generators/simple_form/templates/_form.html.erb
+++ b/lib/generators/simple_form/templates/_form.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
   <%%= f.error_notification %>
 

--- a/lib/generators/simple_form/templates/_form.html.haml
+++ b/lib/generators/simple_form/templates/_form.html.haml
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 = simple_form_for(@<%= singular_table_name %>) do |f|
   = f.error_notification
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   config.error_notification_class = 'alert alert-danger'

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Don't forget to edit this file to adapt it to your needs (specially

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'action_view'
 require 'simple_form/action_view_extensions/form_helper'
 require 'simple_form/action_view_extensions/builder'

--- a/lib/simple_form/action_view_extensions/builder.rb
+++ b/lib/simple_form/action_view_extensions/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module ActionViewExtensions
     # A collection of methods required by simple_form but added to rails default form.

--- a/lib/simple_form/action_view_extensions/form_helper.rb
+++ b/lib/simple_form/action_view_extensions/form_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module ActionViewExtensions
     # This module creates SimpleForm wrappers around default form_for and fields_for.

--- a/lib/simple_form/components.rb
+++ b/lib/simple_form/components.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   # Components are a special type of helpers that can work on their own.
   # For example, by using a component, it will automatically change the

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     module Errors

--- a/lib/simple_form/components/hints.rb
+++ b/lib/simple_form/components/hints.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/components/html5.rb
+++ b/lib/simple_form/components/html5.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     module HTML5

--- a/lib/simple_form/components/label_input.rb
+++ b/lib/simple_form/components/label_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     module LabelInput

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     module Labels

--- a/lib/simple_form/components/maxlength.rb
+++ b/lib/simple_form/components/maxlength.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/components/min_max.rb
+++ b/lib/simple_form/components/min_max.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     module MinMax

--- a/lib/simple_form/components/minlength.rb
+++ b/lib/simple_form/components/minlength.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/components/pattern.rb
+++ b/lib/simple_form/components/pattern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/components/placeholders.rb
+++ b/lib/simple_form/components/placeholders.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/components/readonly.rb
+++ b/lib/simple_form/components/readonly.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Components
     # Needs to be enabled in order to do automatic lookups.

--- a/lib/simple_form/error_notification.rb
+++ b/lib/simple_form/error_notification.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   class ErrorNotification
     delegate :object, :object_name, :template, to: :@builder

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/core_ext/object/deep_dup'
 require 'simple_form/map_type'
 require 'simple_form/tags'

--- a/lib/simple_form/helpers.rb
+++ b/lib/simple_form/helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   # Helpers are made of several helpers that cannot be turned on automatically.
   # For instance, disabled cannot be turned on automatically, it requires the

--- a/lib/simple_form/helpers/autofocus.rb
+++ b/lib/simple_form/helpers/autofocus.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Helpers
     module Autofocus

--- a/lib/simple_form/helpers/disabled.rb
+++ b/lib/simple_form/helpers/disabled.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Helpers
     module Disabled

--- a/lib/simple_form/helpers/readonly.rb
+++ b/lib/simple_form/helpers/readonly.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Helpers
     module Readonly

--- a/lib/simple_form/helpers/required.rb
+++ b/lib/simple_form/helpers/required.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Helpers
     module Required

--- a/lib/simple_form/helpers/validators.rb
+++ b/lib/simple_form/helpers/validators.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Helpers
     module Validators

--- a/lib/simple_form/i18n_cache.rb
+++ b/lib/simple_form/i18n_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   # A lot of configuration values are retrived from I18n,
   # like boolean collection, required string. This module provides

--- a/lib/simple_form/inputs.rb
+++ b/lib/simple_form/inputs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     extend ActiveSupport::Autoload

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'simple_form/i18n_cache'
 require 'active_support/core_ext/string/output_safety'
 require 'action_view/helpers'

--- a/lib/simple_form/inputs/block_input.rb
+++ b/lib/simple_form/inputs/block_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class BlockInput < Base

--- a/lib/simple_form/inputs/boolean_input.rb
+++ b/lib/simple_form/inputs/boolean_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class BooleanInput < Base

--- a/lib/simple_form/inputs/collection_check_boxes_input.rb
+++ b/lib/simple_form/inputs/collection_check_boxes_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class CollectionCheckBoxesInput < CollectionRadioButtonsInput

--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class CollectionInput < Base

--- a/lib/simple_form/inputs/collection_radio_buttons_input.rb
+++ b/lib/simple_form/inputs/collection_radio_buttons_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class CollectionRadioButtonsInput < CollectionInput

--- a/lib/simple_form/inputs/collection_select_input.rb
+++ b/lib/simple_form/inputs/collection_select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class CollectionSelectInput < CollectionInput

--- a/lib/simple_form/inputs/date_time_input.rb
+++ b/lib/simple_form/inputs/date_time_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class DateTimeInput < Base

--- a/lib/simple_form/inputs/file_input.rb
+++ b/lib/simple_form/inputs/file_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class FileInput < Base

--- a/lib/simple_form/inputs/grouped_collection_select_input.rb
+++ b/lib/simple_form/inputs/grouped_collection_select_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class GroupedCollectionSelectInput < CollectionInput

--- a/lib/simple_form/inputs/hidden_input.rb
+++ b/lib/simple_form/inputs/hidden_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class HiddenInput < Base

--- a/lib/simple_form/inputs/numeric_input.rb
+++ b/lib/simple_form/inputs/numeric_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class NumericInput < Base

--- a/lib/simple_form/inputs/password_input.rb
+++ b/lib/simple_form/inputs/password_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class PasswordInput < Base

--- a/lib/simple_form/inputs/priority_input.rb
+++ b/lib/simple_form/inputs/priority_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class PriorityInput < CollectionSelectInput

--- a/lib/simple_form/inputs/range_input.rb
+++ b/lib/simple_form/inputs/range_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class RangeInput < NumericInput

--- a/lib/simple_form/inputs/string_input.rb
+++ b/lib/simple_form/inputs/string_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class StringInput < Base

--- a/lib/simple_form/inputs/text_input.rb
+++ b/lib/simple_form/inputs/text_input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Inputs
     class TextInput < Base

--- a/lib/simple_form/map_type.rb
+++ b/lib/simple_form/map_type.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/core_ext/class/attribute'
 
 module SimpleForm

--- a/lib/simple_form/railtie.rb
+++ b/lib/simple_form/railtie.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/railtie'
 
 module SimpleForm

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Tags
     module CollectionExtensions

--- a/lib/simple_form/version.rb
+++ b/lib/simple_form/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   VERSION = "3.5.0".freeze
 end

--- a/lib/simple_form/wrappers.rb
+++ b/lib/simple_form/wrappers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     autoload :Builder, 'simple_form/wrappers/builder'

--- a/lib/simple_form/wrappers/builder.rb
+++ b/lib/simple_form/wrappers/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     # Provides the builder syntax for components. The builder provides

--- a/lib/simple_form/wrappers/leaf.rb
+++ b/lib/simple_form/wrappers/leaf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     class Leaf

--- a/lib/simple_form/wrappers/many.rb
+++ b/lib/simple_form/wrappers/many.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     # A wrapper is an object that holds several components and render them.

--- a/lib/simple_form/wrappers/root.rb
+++ b/lib/simple_form/wrappers/root.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     # `Root` is the root wrapper for all components. It is special cased to

--- a/lib/simple_form/wrappers/single.rb
+++ b/lib/simple_form/wrappers/single.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SimpleForm
   module Wrappers
     # `Single` is an optimization for a wrapper that has only one component.

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class BuilderTest < ActionView::TestCase

--- a/test/action_view_extensions/form_helper_test.rb
+++ b/test/action_view_extensions/form_helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class FormHelperTest < ActionView::TestCase

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/association_test.rb
+++ b/test/form_builder/association_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/button_test.rb
+++ b/test/form_builder/button_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/error_notification_test.rb
+++ b/test/form_builder/error_notification_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 # Tests for f.error and f.full_error

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/hint_test.rb
+++ b/test/form_builder/hint_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 # Tests for f.hint

--- a/test/form_builder/input_field_test.rb
+++ b/test/form_builder/input_field_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 # Tests for f.input_field

--- a/test/form_builder/label_test.rb
+++ b/test/form_builder/label_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class WrapperTest < ActionView::TestCase

--- a/test/generators/simple_form_generator_test.rb
+++ b/test/generators/simple_form_generator_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class SimpleFormGeneratorTest < Rails::Generators::TestCase

--- a/test/inputs/boolean_input_test.rb
+++ b/test/inputs/boolean_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/datetime_input_test.rb
+++ b/test/inputs/datetime_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/disabled_test.rb
+++ b/test/inputs/disabled_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class DisabledTest < ActionView::TestCase

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class DiscoveryTest < ActionView::TestCase

--- a/test/inputs/file_input_test.rb
+++ b/test/inputs/file_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/grouped_collection_select_input_test.rb
+++ b/test/inputs/grouped_collection_select_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/hidden_input_test.rb
+++ b/test/inputs/hidden_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/numeric_input_test.rb
+++ b/test/inputs/numeric_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/priority_input_test.rb
+++ b/test/inputs/priority_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/readonly_test.rb
+++ b/test/inputs/readonly_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ReadonlyTest < ActionView::TestCase

--- a/test/inputs/required_test.rb
+++ b/test/inputs/required_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class RequiredTest < ActionView::TestCase

--- a/test/inputs/string_input_test.rb
+++ b/test/inputs/string_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/inputs/text_input_test.rb
+++ b/test/inputs/text_input_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 require 'test_helper'
 

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class SimpleFormTest < ActiveSupport::TestCase

--- a/test/support/discovery_inputs.rb
+++ b/test/support/discovery_inputs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StringInput < SimpleForm::Inputs::StringInput
   def input(wrapper_options = nil)
     "<section>#{super}</section>".html_safe

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module MiscHelpers
   def store_translations(locale, translations, &block)
     I18n.backend.store_translations locale, translations

--- a/test/support/mock_controller.rb
+++ b/test/support/mock_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MockController
   attr_writer :action_name
 

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Association = Struct.new(:klass, :name, :macro, :scope, :options)
 
 Column = Struct.new(:name, :type, :limit) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/setup'
 
 require 'minitest/autorun'


### PR DESCRIPTION
I noticed these files all had strings such as "", "  ", "_" that were
allocated each time some common methods were called, over 1000x on a
page in my app. This comment freezes all of these strings such that
they're only allocated once, saving many KB of memory allocation.