### PR TITLE
Fix JRuby build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.3.4
   - 2.4.1
   - ruby-head
-  - jruby
+  - jruby-9.1.14.0
 gemfile:
   - gemfiles/Gemfile.rails-4-0-stable
   - gemfiles/Gemfile.rails-4-1-stable
@@ -28,7 +28,7 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-4-1-stable # activesupport 4.1 depends on json 1.8.3 which does not compile with Ruby 2.4.0
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile.rails-4-1-stable # activesupport 4.1 depends on json 1.8.3 which does not compile with Ruby 2.4.0
-    - rvm: jruby
+    - rvm: jruby-9.1.14.0
       gemfile: Gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.rails-5-0-stable
@@ -36,9 +36,9 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-5-0-stable
     - rvm: 2.1.10
       gemfile: gemfiles/Gemfile.rails-5-0-stable
-    - rvm: jruby
+    - rvm: jruby-9.1.14.0
       gemfile: gemfiles/Gemfile.rails-5-0-stable
-    - rvm: jruby
+    - rvm: jruby-9.1.14.0
       gemfile: gemfiles/Gemfile.rails-5-1-stable # rack 2.0.1 requires Ruby version >= 2.2.2; any sol'n for jruby?
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.rails-5-1-stable # rack 2.0.1 requires Ruby version >= 2.2.2


### PR DESCRIPTION
I don't know why but JRuby build is failing on Travis CI. The output:

```
3.73s$ rvm use jruby --install --binary --fuzzy
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
jruby-9.1.14.0200 is not installed - installing.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Searching for binary rubies, this might take some time.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Unknown ruby string (do not know how to handle): jruby-9.1.14.0200.
Requested binary installation but no rubies are available to download, consider skipping --binary flag.
Gemset '' does not exist, 'rvm jruby-9.1.14.0200 do rvm gemset create ' first, or append '--create'.
```

I think the problem is related to this issue https://github.com/travis-ci/travis-ci/issues/8446.

I am investigating how the best way to solve this problem. If anyone knows anything, feel free to help.

### Update

To get this work I fixed the version 9.1.14.0. 