### PR TITLE
Fix error when the scope from association has parameter

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -461,7 +461,11 @@ module SimpleForm
         relation = reflection.klass.all
 
         if reflection.respond_to?(:scope) && reflection.scope
-          relation = reflection.klass.instance_exec(&reflection.scope)
+          if reflection.scope.parameters.any?
+            relation = reflection.klass.instance_exec(object, &reflection.scope)
+          else
+            relation = reflection.klass.instance_exec(&reflection.scope)
+          end
         else
           order = reflection.options[:order]
           conditions = reflection.options[:conditions]

--- a/test/form_builder/association_test.rb
+++ b/test/form_builder/association_test.rb
@@ -121,6 +121,15 @@ class AssociationTest < ActionView::TestCase
     assert_no_select 'form select option[value="2"]'
   end
 
+  test 'builder allows collection to have a scope with parameter' do
+    with_association_for @user, :special_tags
+    assert_select 'form select.select#user_special_tag_ids'
+    assert_select 'form select[multiple=multiple]'
+    assert_select 'form select option[value="1"]', 'Tag 1'
+    assert_no_select 'form select option[value="2"]'
+    assert_no_select 'form select option[value="3"]'
+  end
+
   test 'builder marks the record which already belongs to the user' do
     @user.company_id = 2
     with_association_for @user, :company, as: :radio_buttons

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -7,7 +7,7 @@ Relation = Struct.new(:records) do
   delegate :each, to: :records
 
   def where(conditions = nil)
-    self.class.new conditions ? records.first : records
+    self.class.new conditions ? [records.first] : records
   end
 
   def order(conditions = nil)

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -83,7 +83,7 @@ class User
     :avatar, :home_picture, :email, :status, :residence_country, :phone_number,
     :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :gender,
     :extra_special_company_id, :pictures, :picture_ids, :special_pictures,
-    :special_picture_ids, :uuid, :friends, :friend_ids
+    :special_picture_ids, :uuid, :friends, :friend_ids, :special_tags, :special_tag_ids
 
   def self.build(extra_attributes = {})
     attributes = {
@@ -204,6 +204,8 @@ class User
         Association.new(Company, association, :belongs_to, nil, {})
       when :tags
         Association.new(Tag, association, :has_many, nil, {})
+      when :special_tags
+        Association.new(Tag, association, :has_many, ->(user) { where(id: user.id) }, {})
       when :first_company
         Association.new(Company, association, :has_one, nil, {})
       when :special_company


### PR DESCRIPTION
This PR solves the issue  https://github.com/plataformatec/simple_form/issues/1519

### TL;DR
As we are using the `instance_exec` to execute the scope from the association, when the scope has a parameter, it's breaking.

The scope's parameter always will be the instance of the own class, so we can fix it using the object instance that simple form uses to build the form.