### PR TITLE
Support for citext, hstore, json & jsonb columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Allow custom errors classes to inputs . [@feliperenan](https://github.com/feliperenan)
 * Remove support from Rails 4.0, 4.1 and 4.2. [@feliperenan](https://github.com/feliperenan)
+* Add support for citext, hstore, json & jsonb column types. [@swrobel](https://github.com/swrobel)
 
 ### Bug fix
 * Fix horizontal form label position, from right to text-right. [@cavpollo](https://github.com/cavpollo)

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ Mapping         | Generated HTML Element               | Database Column Type
 --------------- |--------------------------------------|---------------------
 `boolean`       | `input[type=checkbox]`               | `boolean`
 `string`        | `input[type=text]`                   | `string`
+`citext`        | `input[type=text]`                   | `citext`
 `email`         | `input[type=email]`                  | `string` with `name =~ /email/`
 `url`           | `input[type=url]`                    | `string` with `name =~ /url/`
 `tel`           | `input[type=tel]`                    | `string` with `name =~ /phone/`
@@ -562,6 +563,9 @@ Mapping         | Generated HTML Element               | Database Column Type
 `search`        | `input[type=search]`                 | -
 `uuid`          | `input[type=text]`                   | `uuid`
 `text`          | `textarea`                           | `text`
+`hstore`        | `textarea`                           | `hstore`
+`json`          | `textarea`                           | `json`
+`jsonb`         | `textarea`                           | `jsonb`
 `file`          | `input[type=file]`                   | `string` responding to file methods
 `hidden`        | `input[type=hidden]`                 | -
 `integer`       | `input[type=number]`                 | `integer`

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -527,7 +527,7 @@ module SimpleForm
       case input_type
       when :timestamp
         :datetime
-      when :string, nil
+      when :string, :citext, nil
         case attribute_name.to_s
         when /password/  then :password
         when /time_zone/ then :time_zone

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -18,20 +18,20 @@ module SimpleForm
     extend MapType
     include SimpleForm::Inputs
 
-    map_type :text,                                       to: SimpleForm::Inputs::TextInput
-    map_type :file,                                       to: SimpleForm::Inputs::FileInput
-    map_type :string, :email, :search, :tel, :url, :uuid, to: SimpleForm::Inputs::StringInput
-    map_type :password,                                   to: SimpleForm::Inputs::PasswordInput
-    map_type :integer, :decimal, :float,                  to: SimpleForm::Inputs::NumericInput
-    map_type :range,                                      to: SimpleForm::Inputs::RangeInput
-    map_type :check_boxes,                                to: SimpleForm::Inputs::CollectionCheckBoxesInput
-    map_type :radio_buttons,                              to: SimpleForm::Inputs::CollectionRadioButtonsInput
-    map_type :select,                                     to: SimpleForm::Inputs::CollectionSelectInput
-    map_type :grouped_select,                             to: SimpleForm::Inputs::GroupedCollectionSelectInput
-    map_type :date, :time, :datetime,                     to: SimpleForm::Inputs::DateTimeInput
-    map_type :country, :time_zone,                        to: SimpleForm::Inputs::PriorityInput
-    map_type :boolean,                                    to: SimpleForm::Inputs::BooleanInput
-    map_type :hidden,                                     to: SimpleForm::Inputs::HiddenInput
+    map_type :text, :hstore, :json, :jsonb,                        to: SimpleForm::Inputs::TextInput
+    map_type :file,                                                to: SimpleForm::Inputs::FileInput
+    map_type :string, :email, :search, :tel, :url, :uuid, :citext, to: SimpleForm::Inputs::StringInput
+    map_type :password,                                            to: SimpleForm::Inputs::PasswordInput
+    map_type :integer, :decimal, :float,                           to: SimpleForm::Inputs::NumericInput
+    map_type :range,                                               to: SimpleForm::Inputs::RangeInput
+    map_type :check_boxes,                                         to: SimpleForm::Inputs::CollectionCheckBoxesInput
+    map_type :radio_buttons,                                       to: SimpleForm::Inputs::CollectionRadioButtonsInput
+    map_type :select,                                              to: SimpleForm::Inputs::CollectionSelectInput
+    map_type :grouped_select,                                      to: SimpleForm::Inputs::GroupedCollectionSelectInput
+    map_type :date, :time, :datetime,                              to: SimpleForm::Inputs::DateTimeInput
+    map_type :country, :time_zone,                                 to: SimpleForm::Inputs::PriorityInput
+    map_type :boolean,                                             to: SimpleForm::Inputs::BooleanInput
+    map_type :hidden,                                              to: SimpleForm::Inputs::HiddenInput
 
     def self.discovery_cache
       @discovery_cache ||= {}

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -142,6 +142,24 @@ class FormBuilderTest < ActionView::TestCase
     assert_select 'form input#user_description.string'
   end
 
+  test 'builder generates text areas for hstore columns' do
+    with_form_for @user, :hstore
+    assert_no_select 'form input#user_hstore.string'
+    assert_select 'form textarea#user_hstore.text'
+  end
+
+  test 'builder generates text areas for json columns' do
+    with_form_for @user, :json
+    assert_no_select 'form input#user_json.string'
+    assert_select 'form textarea#user_json.text'
+  end
+
+  test 'builder generates text areas for jsonb columns' do
+    with_form_for @user, :jsonb
+    assert_no_select 'form input#user_jsonb.string'
+    assert_select 'form textarea#user_jsonb.text'
+  end
+
   test 'builder generates a checkbox for boolean columns' do
     with_form_for @user, :active
     assert_select 'form input[type=checkbox]#user_active.boolean'
@@ -164,6 +182,11 @@ class FormBuilderTest < ActionView::TestCase
     else
       assert_select 'form input#user_uuid.string.uuid'
     end
+  end
+
+  test 'builder generates string fields for citext columns' do
+    with_form_for @user, :citext
+    assert_select 'form input#user_citext.string'
   end
 
   test 'builder generates password fields for columns that matches password' do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -90,7 +90,8 @@ class User
     :avatar, :home_picture, :email, :status, :residence_country, :phone_number,
     :post_count, :lock_version, :amount, :attempts, :action, :credit_card, :gender,
     :extra_special_company_id, :pictures, :picture_ids, :special_pictures,
-    :special_picture_ids, :uuid, :friends, :friend_ids, :special_tags, :special_tag_ids
+    :special_picture_ids, :uuid, :friends, :friend_ids, :special_tags, :special_tag_ids,
+    :citext, :hstore, :json, :jsonb
 
   def self.build(extra_attributes = {})
     attributes = {
@@ -141,7 +142,7 @@ class User
       when :attempts      then :integer
       when :action        then :string
       when :credit_card   then :string
-      when :uuid          then :uuid
+      else attribute.to_sym
     end
     Column.new(attribute, column_type, limit)
   end
@@ -175,6 +176,10 @@ class User
         when 'action'        then :string
         when 'credit_card'   then :string
         when 'uuid'          then :string
+        when 'citext'        then :string
+        when 'hstore'        then [:text, 200]
+        when 'json'          then [:text, 200]
+        when 'jsonb'         then [:text, 200]
       end
 
       ActiveModel::Type.lookup(column_type, limit: limit)
@@ -187,7 +192,8 @@ class User
       when :name, :status, :password, :description, :age,
         :credit_limit, :active, :born_at, :delivery_time,
         :created_at, :updated_at, :lock_version, :home_picture,
-        :amount, :attempts, :action, :credit_card, :uuid then true
+        :amount, :attempts, :action, :credit_card, :uuid,
+        :citext, :hstore, :json, :jsonb then true
       else false
     end
   end


### PR DESCRIPTION
These are all commonly-used Postgres types. Fixes #1484 

@rafaelfranca I added tests but I'm concerned that they aren't actually accomplishing what they're supposed to. I tried using `uuid` as an example and deleted [the mapping](https://github.com/plataformatec/simple_form/blob/v3.5.0/lib/simple_form/form_builder.rb#L22) for that from `form_builder.rb` but the tests for it still passed. I believe that [test/support/models.rb](https://github.com/plataformatec/simple_form/blob/master/test/support/models.rb) might be responsible for the tests passing rather than the actual mapping from the gem. I'm a bit confused. However, this does work correctly in my application where I was using the previous workaround, so there's that.