### PR TITLE
Fix boolean inputs in nested style for label non-string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Check if Rails.env is defined. [@etagwerker](https://github.com/etagwerker)
 * Fix minlength. [@mameier](https://github.com/mameier)
 * Make errors_on_attribute return [] when not present. [@redrick](https://github.com/redrick)
+* Fix boolean inputs in nested style for label non-string. [@feliperenan](https://github.com/feliperenan)
 
 ## 3.5.0
 

--- a/lib/simple_form/inputs/collection_check_boxes_input.rb
+++ b/lib/simple_form/inputs/collection_check_boxes_input.rb
@@ -11,7 +11,7 @@ module SimpleForm
       end
 
       def build_nested_boolean_style_item_tag(collection_builder)
-        collection_builder.check_box + collection_builder.text
+        collection_builder.check_box + collection_builder.text.to_s
       end
 
       def item_wrapper_class

--- a/lib/simple_form/inputs/collection_radio_buttons_input.rb
+++ b/lib/simple_form/inputs/collection_radio_buttons_input.rb
@@ -41,7 +41,7 @@ module SimpleForm
       end
 
       def build_nested_boolean_style_item_tag(collection_builder)
-        collection_builder.radio_button + collection_builder.text
+        collection_builder.radio_button + collection_builder.text.to_s
       end
 
       def item_wrapper_class

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -301,4 +301,19 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'input check boxes with nested style accepts non-string attribute as label' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :amount,
+                            :check_boxes,
+                            collection: { 100 => 'hundred', 200 => 'two_hundred' },
+                            label_method: :first,
+                            value_method: :second
+
+      assert_select 'input[type=checkbox][value=hundred]'
+      assert_select 'input[type=checkbox][value=two_hundred]'
+      assert_select 'span.checkbox > label', '100'
+      assert_select 'span.checkbox > label', '200'
+    end
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -424,4 +424,19 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'label[for=user_1_gender_female]'
     end
   end
+
+  test 'input radio with nested style accetps non-string attribute as label' do
+    swap SimpleForm, boolean_style: :nested do
+      with_input_for @user, :amount,
+                            :radio_buttons,
+                            collection: { 100 => 'hundred', 200 => 'two_hundred' },
+                            label_method: :first,
+                            value_method: :second
+
+      assert_select 'input[type=radio][value=hundred]'
+      assert_select 'input[type=radio][value=two_hundred]'
+      assert_select 'span.radio > label', '100'
+      assert_select 'span.radio > label', '200'
+    end
+  end
 end


### PR DESCRIPTION
### Context
Simple Form is rendering the character value instead the non-string value when the input is radio or checkbox in boolean nested style and have a collection that the first item is a non-string value

When Simple Form is building the label tag, it concatenates the input HTML that is a string with the attribute from a collection that should be a string too. If it is not, it will convert the attribute to a character before concatenation.

### Before
![image](https://user-images.githubusercontent.com/27698968/35655101-4634f40a-06d7-11e8-8add-07cd3a7a6d02.png)

### After
![image](https://user-images.githubusercontent.com/27698968/35655037-052fd718-06d7-11e8-86d1-c958cbc0c2c9.png)


### TL;DR
The input generated by the collection_builder is a [ActiveSupport](http://api.rubyonrails.org/classes/ActiveSupport/SafeBuffer.html#method-i-2B) instance. So when the method `+` is called it's calling the [String#concat.](https://ruby-doc.org/core-1.9.2/String.html).

```bash
collection_builder.radio_button + 1
=> "<input class=\"radio_buttons \" id=\"user_amount\" />\u0001"

collection_builder.radio_button + 1.to_s
=> "<input class=\"radio_buttons \" id=\"user_amount\" />1"
```
