### PR TITLE
Fix horizontal form label position, from right to text-right

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -32,7 +32,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     b.wrapper :label_wrapper, tag: :div, class: 'small-3 columns' do |ba|
-      ba.use :label, class: 'right inline'
+      ba.use :label, class: 'text-right inline'
     end
 
     b.wrapper :right_input_wrapper, tag: :div, class: 'small-9 columns' do |ba|


### PR DESCRIPTION
As mentioned in the issue #1339 (some years ago), the position for the labels when using the horizontal form class was wrong.
This PR fixes the label alignment problem by making the "right" class become "text-right". :slightly_smiling_face: 