### PR TITLE
Allow custom errors classes to inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-* Remove support from Rails 4.0, 4.1 and 4.2 [@feliperenan](https://github.com/feliperenan)
+* Allow custom errors classes to inputs . [@feliperenan](https://github.com/feliperenan)
+* Remove support from Rails 4.0, 4.1 and 4.2. [@feliperenan](https://github.com/feliperenan)
 
 ### Bug fix
 * Fix horizontal form label position, from right to text-right. [@cavpollo](https://github.com/cavpollo)

--- a/README.md
+++ b/README.md
@@ -901,11 +901,12 @@ You can customize _Form components_ passing options to them:
 
 ```ruby
 config.wrappers do |b|
-  b.use :label_input, class: 'label-input-class'
+  b.use :label_input, class: 'label-input-class', error_class: 'is-invalid'
 end
 ```
 
-This you set the input and label class to `'label-input-class'`.
+This you set the input and label class to `'label-input-class'` and will set the class `'is-invalid'` 
+when the input has errors.
 
 If you want to customize the custom _Form components_ on demand you can give it a name like this:
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -45,6 +45,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid'
     b.use :label_input
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
     b.use :error, wrap_with: { tag: :span, class: :error }

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -191,6 +191,8 @@ module SimpleForm
 
       def merge_wrapper_options(options, wrapper_options)
         if wrapper_options
+          wrapper_options = set_input_classes(wrapper_options)
+
           wrapper_options.merge(options) do |key, oldval, newval|
             case key.to_s
             when "class"
@@ -204,6 +206,17 @@ module SimpleForm
         else
           options
         end
+      end
+
+      def set_input_classes(wrapper_options)
+        wrapper_options = wrapper_options.dup
+        error_class     = wrapper_options.delete(:error_class)
+
+        if error_class.present? && has_errors?
+          wrapper_options[:class] = "#{wrapper_options[:class]} #{error_class}"
+        end
+
+        wrapper_options
       end
 
       def i18n_scope

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -38,6 +38,18 @@ class WrapperTest < ActionView::TestCase
     assert_select 'div.field_with_errors'
   end
 
+  test 'wrapper adds error class to input for attribute with errors' do
+    with_form_for @user, :name, wrapper: custom_wrapper_with_input_error_class
+    assert_select 'div.field_with_errors'
+    assert_select 'input.is-invalid'
+  end
+
+  test 'wrapper does not add error class to input when the attribute is valid' do
+    with_form_for @user, :phone_number, wrapper: custom_wrapper_with_input_error_class
+    assert_no_select 'div.field_with_errors'
+    assert_no_select 'input.is-invalid'
+  end
+
   test 'wrapper adds hint class for attribute with a hint' do
     with_form_for @user, :name, hint: 'hint'
     assert_select 'div.field_with_hint'

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -206,6 +206,13 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_input_error_class
+    SimpleForm.build tag: :div, class: "custom_wrapper", error_class: :field_with_errors do |b|
+      b.use :label
+      b.use :input, class: 'inline-class', error_class: 'is-invalid'
+    end
+  end
+
   def custom_form_for(object, *args, &block)
     simple_form_for(object, *args, { builder: CustomFormBuilder }, &block)
   end


### PR DESCRIPTION
Allow custom errors classes to input in our wrappers. With it, when a validation happens, the input will be rendered with the error class defined in the wrapper.

### Examples

We can configure an wrapper:
```ruby
  config.wrappers :form, tag: 'div', class: 'field', error_class: 'invalid' do |b|
    b.use :label

    b.use :input, error_class: 'is-invalid'
  end
```

And when a form with errors be rendered, will generated the follow markup:

```HTML
<div class="field invalid">
  <input class="string required is-invalid" type="text" value="ok" name="user[name]" id="user_name">
</div>
```

### Example working on Bootstrap 4
![2018-03-03 01 48 45](https://user-images.githubusercontent.com/27698968/36930682-2510e976-1e85-11e8-8347-bf18ee7542d0.gif)

Thank you @CharlieHawker by #1476 and #1475




