### PR TITLE
Add :valid_class on input wrapper when value is present and valid v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Allow custom errors classes to inputs.[@feliperenan](https://github.com/feliperenan)
 * Remove support from Rails 4.0, 4.1 and 4.2. [@feliperenan](https://github.com/feliperenan)
 * Add support for citext, hstore, json & jsonb column types. [@swrobel](https://github.com/swrobel)
+* Add :valid_class on input wrapper when value is present and valid [@aeberlin](https://github.com/aeberlin), [@m5o](https://github.com/m5o)
 
 ### Bug fix
 * Fix horizontal form label position, from right to text-right. [@cavpollo](https://github.com/cavpollo)

--- a/README.md
+++ b/README.md
@@ -856,7 +856,8 @@ The syntax looks like this:
 
 ```ruby
 config.wrappers tag: :div, class: :input,
-                error_class: :field_with_errors do |b|
+                error_class: :field_with_errors,
+                valid_class: :field_without_errors do |b|
 
   # Form extensions
   b.use :html5

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -14,7 +14,7 @@ SimpleForm.setup do |config|
   # stack. The options given below are used to wrap the
   # whole input.
   config.wrappers :default, class: :input,
-    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
     ## Extensions enabled by default
     # Any of these extensions can be disabled for a
     # given input by passing: `f.input EXTENSION_NAME => false`.

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -12,7 +12,7 @@ SimpleForm.setup do |config|
   config.button_class = 'btn btn-default'
   config.boolean_label_class = nil
 
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -27,7 +27,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -40,7 +40,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -52,7 +52,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'
@@ -61,7 +61,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -78,7 +78,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -93,7 +93,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -107,7 +107,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -120,7 +120,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -135,7 +135,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'has-success' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -12,7 +12,7 @@ SimpleForm.setup do |config|
   config.button_class = 'btn btn-default'
   config.boolean_label_class = nil
 
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -27,7 +27,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -40,7 +40,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -52,7 +52,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'
@@ -61,7 +61,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -78,7 +78,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -93,7 +93,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -107,7 +107,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -120,7 +120,7 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -135,7 +135,7 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error', valid_class: 'no-error' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -15,7 +15,7 @@ SimpleForm.setup do |config|
   # doesn't provide styles for hints. You will need to provide your own CSS styles for hints.
   # Uncomment them to enable hints.
 
-  config.wrappers :vertical_form, class: :input, hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :vertical_form, class: :input, hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -29,7 +29,7 @@ SimpleForm.setup do |config|
     # b.use :hint,  wrap_with: { tag: :span, class: :hint }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'row', hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :horizontal_form, tag: 'div', class: 'row', hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -71,7 +71,7 @@ SimpleForm.setup do |config|
   # Note that you need to adapt this wrapper to your needs. If you need a 4
   # columns form then change the wrapper class to 'small-3', if you need
   # only two use 'small-6' and so on.
-  config.wrappers :inline_form, tag: 'div', class: 'column small-4', hint_class: :field_with_hint, error_class: :error do |b|
+  config.wrappers :inline_form, tag: 'div', class: 'column small-4', hint_class: :field_with_hint, error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -90,7 +90,7 @@ SimpleForm.setup do |config|
   # Examples of use:
   # - wrapper_html: {class: 'row'}, custom_wrapper_html: {class: 'column small-12'}
   # - custom_wrapper_html: {class: 'column small-3 end'}
-  config.wrappers :customizable_wrapper, tag: 'div', error_class: :error do |b|
+  config.wrappers :customizable_wrapper, tag: 'div', error_class: :error, valid_class: :valid do |b|
     b.use :html5
     b.optional :readonly
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -229,7 +229,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
     SimpleForm::Wrappers::Root.new(builder.to_a, options)
   end
 
-  wrappers class: :input, hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+  wrappers class: :input, hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
     b.use :html5
 
     b.use :min_max

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -15,9 +15,7 @@ module SimpleForm
       end
 
       def has_value?
-        return false unless object && object.respond_to?(attribute_name)
-
-        object.send(attribute_name).present?
+        object && object.respond_to?(attribute_name) && object.send(attribute_name).present?
       end
 
       def valid?

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -15,7 +15,7 @@ module SimpleForm
       end
 
       def has_value?
-        return unless object && object.respond_to?(attribute_name)
+        return false unless object && object.respond_to?(attribute_name)
 
         object.send(attribute_name).present?
       end

--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -14,6 +14,16 @@ module SimpleForm
         object && object.respond_to?(:errors) && errors.present?
       end
 
+      def has_value?
+        return unless object && object.respond_to?(attribute_name)
+
+        object.send(attribute_name).present?
+      end
+
+      def valid?
+        !has_errors? && has_value?
+      end
+
       protected
 
       def error_text

--- a/lib/simple_form/wrappers/root.rb
+++ b/lib/simple_form/wrappers/root.rb
@@ -30,6 +30,7 @@ module SimpleForm
         end
         css << (options[:wrapper_error_class] || @defaults[:error_class]) if input.has_errors?
         css << (options[:wrapper_hint_class] || @defaults[:hint_class]) if input.has_hint?
+        css << (options[:wrapper_valid_class] || @defaults[:valid_class]) if input.valid?
         css.compact
       end
     end

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -272,14 +272,4 @@ class ErrorTest < ActionView::TestCase
       assert_no_select 'span.error'
     end
   end
-
-  test 'input wrapper has valid class for present attribute without errors' do
-    @user.instance_eval do
-      undef errors
-      name = 'foo'
-    end
-
-    with_form_for @user, :name
-    assert_select '.input.field_without_errors'
-  end
 end

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -273,8 +273,6 @@ class ErrorTest < ActionView::TestCase
     end
   end
 
-  # NO ERRORS
-
   test 'input wrapper has valid class for present attribute without errors' do
     @user.instance_eval do
       undef errors

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -272,4 +272,16 @@ class ErrorTest < ActionView::TestCase
       assert_no_select 'span.error'
     end
   end
+
+  # NO ERRORS
+
+  test 'input wrapper has valid class for present attribute without errors' do
+    @user.instance_eval do
+      undef errors
+      name = 'foo'
+    end
+
+    with_form_for @user, :name
+    assert_select '.input.field_without_errors'
+  end
 end

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -242,6 +242,7 @@ class FormBuilderTest < ActionView::TestCase
   test 'builder generates file for file columns' do
     @user.avatar = MiniTest::Mock.new
     @user.avatar.expect(:public_filename, true)
+    @user.avatar.expect(:!, false)
 
     with_form_for @user, :avatar
     assert_select 'form input#user_avatar.file'
@@ -250,6 +251,7 @@ class FormBuilderTest < ActionView::TestCase
   test 'builder generates file for attributes that are real db columns but have file methods' do
     @user.home_picture = MiniTest::Mock.new
     @user.home_picture.expect(:mounted_as, true)
+    @user.home_picture.expect(:!, false)
 
     with_form_for @user, :home_picture
     assert_select 'form input#user_home_picture.file'

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -50,6 +50,12 @@ class WrapperTest < ActionView::TestCase
     assert_no_select 'input.is-invalid'
   end
 
+  test 'wrapper adds valid class for present attribute without errors' do
+    @user.instance_eval { undef errors }
+    with_form_for @user, :name, wrapper: custom_wrapper_with_input_valid_class
+    assert_select 'div.field_without_errors'
+  end
+
   test 'wrapper adds hint class for attribute with a hint' do
     with_form_for @user, :name, hint: 'hint'
     assert_select 'div.field_with_hint'

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -54,6 +54,7 @@ class WrapperTest < ActionView::TestCase
     @user.instance_eval { undef errors }
     with_form_for @user, :name, wrapper: custom_wrapper_with_input_valid_class
     assert_select 'div.field_without_errors'
+    assert_no_select 'div.field_with_errors'
   end
 
   test 'wrapper adds hint class for attribute with a hint' do

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -213,6 +213,13 @@ module MiscHelpers
     end
   end
 
+  def custom_wrapper_with_input_valid_class
+    SimpleForm.build tag: :div, class: "custom_wrapper", valid_class: :field_without_errors do |b|
+      b.use :label
+      b.use :input, class: 'inline-class'
+    end
+  end
+
   def custom_form_for(object, *args, &block)
     simple_form_for(object, *args, { builder: CustomFormBuilder }, &block)
   end


### PR DESCRIPTION
This just continues the great work started by @aeberlin with #1333 

---

##### Purpose

The purpose of this PR is to improve style support for inputs with validations. Simply put, the lack of an applied `:error_class` is not indicative of the attribute being valid. While this isn't a guaranteed method of determining if it is valid, it is as close as programmatically possible (AFAIK). See caveats below.

##### Logic

When a `:valid_class` is specified, it will be applied to an input wrapper given the following conditions:

1. Object exists.
1. Object responds to `:errors`.
1. There are no validation errors (e.g. validations passed or were not specified).
1. Object responds to the attribute method.
1. Return value of attribute method is present.

##### Changes

1. Added `:valid_class` declarations (similar to those for `:error_class`) on default wrappers.
1. Added `:has_value?` and `:valid?` to `SimpleForm::Components::Errors`.
1. Adjusted `SimpleForm::Wrappers::Root#html_classes` to apply `:valid_class` when applicable.

##### Known caveats

If an attribute is valid when `:blank?`, the `:valid_class` will not be applied. I am open to suggestions here, as this is the only hole in my logic, albeit an acceptable and predictable one (IMO).

##### Further notes

I adjusted two failing tests that were missing stubs, and added another test for this feature.

Please let me know if there's something else I should include. Thanks, cheers!