### PR TITLE
add InputGroup component

### DIFF
--- a/lib/simple_form/components.rb
+++ b/lib/simple_form/components.rb
@@ -12,6 +12,7 @@ module SimpleForm
     autoload :Errors
     autoload :Hints
     autoload :HTML5
+    autoload :InputGroups
     autoload :LabelInput
     autoload :Labels
     autoload :MinMax

--- a/lib/simple_form/components/input_groups.rb
+++ b/lib/simple_form/components/input_groups.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module SimpleForm
+  module Components
+    module InputGroups
+      module Prepends
+        def prepend(wrapper_options = nil)
+          template.content_tag(:div, content_tag(:span, options[:prepend], class: "input-group-text"), class: "input-group-prepend")
+        end
+      end
+
+      module Appends
+        def append(wrapper_options = nil)
+          template.content_tag(:div, content_tag(:span, options[:append], class: "input-group-text"), class: "input-group-append")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a spin off and draft after @rafaelfranca's [comment](https://github.com/rafaelfranca/simple_form-bootstrap/pull/56#discussion_r172645536) on https://github.com/rafaelfranca/simple_form-bootstrap/pull/56

* add InputGroup component

Currently the [_form.html.erb](https://github.com/rafaelfranca/simple_form-bootstrap/pull/56/files#diff-f7c4112a5b12258f4d3de675692a6c2b) requires an custom `:input_group` wrapper

```rb
SimpleForm.setup do |config|
  # Input Group
  config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid' do |b|
    b.use :html5
    b.use :placeholder
    b.optional :maxlength
    b.optional :minlength
    b.optional :pattern
    b.optional :min_max
    b.optional :readonly
    b.use :label, class: 'form-control-label'
    b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
      ba.optional :prepend
      ba.use :input, class: 'form-control', error_class: 'is-invalid'
      ba.optional :append
    end
    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
  end
end
```

I've initially thought because [Bootstrap Input Groups](https://getbootstrap.com/docs/4.0/components/input-group/) are a feature explicitly used by bootstrap a global simple_form component doesn't make sense. Let's discuss.