### PR TITLE
Add API to register custom components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-* Allow custom errors classes to inputs . [@feliperenan](https://github.com/feliperenan)
+* Add API to register custom components.[@feliperenan](https://github.com/feliperenan)
+* Allow custom errors classes to inputs.[@feliperenan](https://github.com/feliperenan)
 * Remove support from Rails 4.0, 4.1 and 4.2. [@feliperenan](https://github.com/feliperenan)
 * Add support for citext, hstore, json & jsonb column types. [@swrobel](https://github.com/swrobel)
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   config.error_notification_class = 'alert alert-danger'

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_foundation.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Don't forget to edit this file to adapt it to your needs (specially

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -265,6 +265,49 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
     @@configured = true
     yield self
   end
+
+  # Includes a component to be used by Simple Form. Methods defined in a
+  # component will be exposed to be used in the wrapper as Simple::Components
+  #
+  # Examples
+  #
+  #    # The application needs to tell where the components will be.
+  #    Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+  #
+  #    # Create a custom component in the path specified above.
+  #    # lib/components/input_group_component.rb
+  #    module InputGroupComponent
+  #      def prepend
+  #        ...
+  #      end
+  #
+  #      def append
+  #        ...
+  #      end
+  #    end
+  #
+  #    SimpleForm.setup do |config|
+  #      # Create a wrapper using the custom component.
+  #      config.wrappers :input_group, tag: :div, error_class: :error do |b|
+  #        b.use :label
+  #        b.optional :prepend
+  #        b.use :input
+  #        b.use :append
+  #      end
+  #    end
+  #
+  #    # Using the custom component in the form.
+  #    <%= simple_form_for @blog, wrapper: input_group do |f| %>
+  #      <%= f.input :title, prepend: true %>
+  #    <% end %>
+  #
+  def self.include_component(component)
+    if Module === component
+      SimpleForm::Inputs::Base.include(component)
+    else
+      raise TypeError, "SimpleForm.include_component expects a module but got: #{component.class}"
+    end
+  end
 end
 
 require 'simple_form/railtie' if defined?(Rails)

--- a/test/components/custom_components_test.rb
+++ b/test/components/custom_components_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Module that represents a custom component.
+module Numbers
+  def number(wrapper_options = nil)
+    @number ||= options[:number].to_s.html_safe
+  end
+end
+
+# Module that represents a custom component.
+module InputGroup
+  def prepend(wrapper_options = nil)
+    span_tag = content_tag(:span, options[:prepend], class: 'input-group-text')
+    template.content_tag(:div, span_tag, class: 'input-group-prepend')
+  end
+
+  def append(wrapper_options = nil)
+    span_tag = content_tag(:span, options[:append], class: 'input-group-text')
+    template.content_tag(:div, span_tag, class: 'input-group-append')
+  end
+end
+
+class CustomComponentsTest < ActionView::TestCase
+  test 'includes the custom components' do
+    SimpleForm.include_component Numbers
+
+    custom_wrapper = SimpleForm.build tag: :div, class: "custom_wrapper" do |b|
+      b.use :number, wrap_with: { tag: 'div', class: 'number' }
+    end
+
+    with_form_for @user, :name, number: 1, wrapper: custom_wrapper
+
+    assert_select 'div.number', text: '1'
+  end
+
+  test 'includes custom components and use it as optional in the wrapper' do
+    SimpleForm.include_component InputGroup
+
+    custom_wrapper = SimpleForm.build tag: :div, class: 'custom_wrapper' do |b|
+      b.use :label
+      b.optional :prepend
+      b.use :input
+      b.use :append
+    end
+
+    with_form_for @user, :name, prepend: true, wrapper: custom_wrapper
+
+    assert_select 'div.input-group-prepend > span.input-group-text'
+    assert_select 'div.input-group-append > span.input-group-text'
+  end
+
+  test 'raises a TypeError when the component is not a Module' do
+    component = 'MyComponent'
+
+    exception = assert_raises TypeError do 
+      SimpleForm.include_component(component)
+    end
+    assert_equal exception.message, "SimpleForm.include_component expects a module but got: String"
+  end
+end


### PR DESCRIPTION
Related to https://github.com/plataformatec/simple_form/issues/1176 and more discussion about it in https://github.com/plataformatec/simple_form/pull/1554

This is a public API to allow users register custom components without monkey patching Simple Form.

### Examples

- Create your custom component.
```ruby
# lib/components/input_group_component.rb
module InputGroup
  def preprend
    ...
  end

  def append
    ...
  end
end

# Register the component in Simple Form.
SimpleForm.include_component(InputGroup)
```

- Tells to Simple Form  the place that the components will be
```ruby
# app/config/initializers/simple_form.rb
Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
```

- Use the custom component in some wrapper.
```ruby
# app/config/initializers/simple_form.rb
SimpleForm.setup do |config|
  # Create a wrapper using the custom component.
  config.wrappers :input_group, tag: :div, error_class: :error do |b|
    b.use :label
    b.optional :prepend
    b.use :input
    b.use :append
  end
end
```

- Using wrapper with the custom component.

```ruby
<%= simple_form_for @blog, wrapper: input_group do |f| %>
  <%= f.input :title, prepend: true %>
<% end %>
```

### Notes

For while, it is just a idea. I'm open for suggestions 😄 

### Todo
- [x] Add tests 
- [x] Add docs
- [x] Update generator