### PR TITLE
allow valid class to inputs if value is present & valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove support from Rails 4.0, 4.1 and 4.2. [@feliperenan](https://github.com/feliperenan)
 * Add support for citext, hstore, json & jsonb column types. [@swrobel](https://github.com/swrobel)
 * Add :valid_class on input wrapper when value is present and valid [@aeberlin](https://github.com/aeberlin), [@m5o](https://github.com/m5o)
+* Allow :valid_class to inputs when value is present and valid. [@m5o](https://github.com/m5o)
 
 ### Bug fix
 * Fix horizontal form label position, from right to text-right. [@cavpollo](https://github.com/cavpollo)

--- a/README.md
+++ b/README.md
@@ -906,12 +906,12 @@ You can customize _Form components_ passing options to them:
 
 ```ruby
 config.wrappers do |b|
-  b.use :label_input, class: 'label-input-class', error_class: 'is-invalid'
+  b.use :label_input, class: 'label-input-class', error_class: 'is-invalid', valid_class: 'is-valid'
 end
 ```
 
-This you set the input and label class to `'label-input-class'` and will set the class `'is-invalid'` 
-when the input has errors.
+This you set the input and label class to `'label-input-class'` and will set the class `'is-invalid'`
+when the input has errors and `'is-valid'` if the input is valid.
 
 If you want to customize the custom _Form components_ on demand you can give it a name like this:
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -52,7 +52,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     ## Inputs
-    # b.use :input, class: 'input', error_class: 'is-invalid'
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label_input
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
     b.use :error, wrap_with: { tag: :span, class: :error }

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -211,9 +211,14 @@ module SimpleForm
       def set_input_classes(wrapper_options)
         wrapper_options = wrapper_options.dup
         error_class     = wrapper_options.delete(:error_class)
+        valid_class     = wrapper_options.delete(:valid_class)
 
         if error_class.present? && has_errors?
           wrapper_options[:class] = "#{wrapper_options[:class]} #{error_class}"
+        end
+
+        if valid_class.present? && valid?
+          wrapper_options[:class] = "#{wrapper_options[:class]} #{valid_class}"
         end
 
         wrapper_options

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -54,7 +54,9 @@ class WrapperTest < ActionView::TestCase
     @user.instance_eval { undef errors }
     with_form_for @user, :name, wrapper: custom_wrapper_with_input_valid_class
     assert_select 'div.field_without_errors'
+    assert_select 'input.is-valid'
     assert_no_select 'div.field_with_errors'
+    assert_no_select 'input.is-invalid'
   end
 
   test 'wrapper adds hint class for attribute with a hint' do

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -216,7 +216,7 @@ module MiscHelpers
   def custom_wrapper_with_input_valid_class
     SimpleForm.build tag: :div, class: "custom_wrapper", valid_class: :field_without_errors do |b|
       b.use :label
-      b.use :input, class: 'inline-class'
+      b.use :input, class: 'inline-class', valid_class: 'is-valid'
     end
   end
 


### PR DESCRIPTION
This is just the consequent follow-up after https://github.com/plataformatec/simple_form/pull/1553 introduced valid_class on input wrapper.

* allow **valid class** to **inputs** if value is present & valid 💚 
* template and implementation pattern:
🔗 https://github.com/plataformatec/simple_form/pull/1552

Would add framework support for [Server Side Form](https://getbootstrap.com/docs/4.0/components/forms/#server-side) like Bootstrap. 

📺 [Demo App](https://simple-form-bootstrap4.herokuapp.com/examples/vertical)


###### See green highlight on Name field 
![valid_class](https://user-images.githubusercontent.com/26371/37863923-ee742278-2f66-11e8-9ee1-ea3bc9e57e14.gif)