### PR TITLE
Use custom i18n scope for label required html

### DIFF
--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -7,18 +7,24 @@ module SimpleForm
       module ClassMethods #:nodoc:
         def translate_required_html
           i18n_cache :translate_required_html do
-            I18n.t(:"simple_form.required.html", default:
+            I18n.t(:"required.html", scope: i18n_scope, default:
               %(<abbr title="#{translate_required_text}">#{translate_required_mark}</abbr>)
             )
           end
         end
 
         def translate_required_text
-          I18n.t(:"simple_form.required.text", default: 'required')
+          I18n.t(:"required.text", scope: i18n_scope, default: 'required')
         end
 
         def translate_required_mark
-          I18n.t(:"simple_form.required.mark", default: '*')
+          I18n.t(:"required.mark", scope: i18n_scope, default: '*')
+        end
+
+        private
+
+        def i18n_scope
+          SimpleForm.i18n_scope
         end
       end
 

--- a/test/components/label_test.rb
+++ b/test/components/label_test.rb
@@ -249,10 +249,28 @@ class IsolatedLabelTest < ActionView::TestCase
     end
   end
 
+  test 'label uses custom i18n scope to find required text' do
+    store_translations(:en, my_scope: { required: { text: 'Pflichtfeld' } }) do
+      swap SimpleForm, i18n_scope: :my_scope do
+        with_label_for @user, :name, :string
+        assert_select 'form label abbr[title="Pflichtfeld"]', '*'
+      end
+    end
+  end
+
   test 'label uses i18n to find required mark' do
     store_translations(:en, simple_form: { required: { mark: '*-*' } }) do
       with_label_for @user, :name, :string
       assert_select 'form label abbr', '*-*'
+    end
+  end
+
+  test 'label uses custom i18n scope to find required mark' do
+    store_translations(:en, my_scope: { required: { mark: '!!' } }) do
+      swap SimpleForm, i18n_scope: :my_scope do
+        with_label_for @user, :name, :string
+        assert_select 'form label abbr', '!!'
+      end
     end
   end
 
@@ -261,6 +279,16 @@ class IsolatedLabelTest < ActionView::TestCase
       with_label_for @user, :name, :string
       assert_no_select 'form label abbr'
       assert_select 'form label span.required[title=requerido]', '*'
+    end
+  end
+
+  test 'label uses custom i18n scope to find required string tag' do
+    store_translations(:en, my_scope: { required: { html: '<span class="mandatory" title="Pflichtfeld">!!</span>' } }) do
+      swap SimpleForm, i18n_scope: :my_scope do
+        with_label_for @user, :name, :string
+        assert_no_select 'form label abbr'
+        assert_select 'form label span.mandatory[title=Pflichtfeld]', '!!'
+      end
     end
   end
 


### PR DESCRIPTION
Since 3.1 it is possible to set a custom `i18n_scope`. This was not
respected to build the required html for label inputs.