### PR TITLE
add basic activestorage support

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -133,7 +133,7 @@ SimpleForm.setup do |config|
   config.browser_validations = false
 
   # Collection of methods to detect if a file type was given.
-  # config.file_methods = [ :mounted_as, :file?, :public_filename ]
+  # config.file_methods = [ :mounted_as, :file?, :public_filename :attached? ]
 
   # Custom mappings for input types. This should be a hash containing a regexp
   # to match as key, and the input type that will be used when the field name

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -122,7 +122,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
 
   # Collection of methods to detect if a file type was given.
   mattr_accessor :file_methods
-  @@file_methods = %i[mounted_as file? public_filename]
+  @@file_methods = %i[mounted_as file? public_filename attached?]
 
   # Custom mappings for input types. This should be a hash containing a regexp
   # to match as key, and the input type that will be used when the field name

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -248,6 +248,15 @@ class FormBuilderTest < ActionView::TestCase
     assert_select 'form input#user_avatar.file'
   end
 
+  test 'builder generates file for activestorage entries' do
+    @user.avatar = MiniTest::Mock.new
+    @user.avatar.expect(:attached?, false)
+    @user.avatar.expect(:!, false)
+
+    with_form_for @user, :avatar
+    assert_select 'form input#user_avatar.file'
+  end
+
   test 'builder generates file for attributes that are real db columns but have file methods' do
     @user.home_picture = MiniTest::Mock.new
     @user.home_picture.expect(:mounted_as, true)


### PR DESCRIPTION
Added a check for the `attached?` method; which is typical for ActiveStorage, bundled with Rails 5.2

Future improvement would be setting multiple automatically to true when the class is an `ActiveStorage::Attached::Many`.