### PR TITLE
Improve disabled option to input_field

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -165,7 +165,7 @@ module SimpleForm
       components = (wrapper.components.map(&:namespace) & ATTRIBUTE_COMPONENTS)
 
       options = options.dup
-      options[:input_html] = options.except(:as, :boolean_style, :collection, :label_method, :value_method, :prompt, *components)
+      options[:input_html] = options.except(:as, :boolean_style, :collection, :disabled, :label_method, :value_method, :prompt, *components)
       options = @defaults.deep_dup.deep_merge(options) if @defaults
 
       input      = find_input(attribute_name, options)

--- a/test/form_builder/input_field_test.rb
+++ b/test/form_builder/input_field_test.rb
@@ -3,12 +3,6 @@ require 'test_helper'
 
 # Tests for f.input_field
 class InputFieldTest < ActionView::TestCase
-  def with_input_field_for(object, *args)
-    with_concat_form_for(object) do |f|
-      f.input_field(*args)
-    end
-  end
-
   test "builder input_field only renders the input tag, nothing else" do
     with_input_field_for @user, :name
 

--- a/test/inputs/disabled_test.rb
+++ b/test/inputs/disabled_test.rb
@@ -76,4 +76,17 @@ class DisabledTest < ActionView::TestCase
     with_input_for @user, :created_at, :datetime
     assert_no_select 'select.datetime.disabled[disabled]'
   end
+
+  test 'input_field collection allows disabled select' do
+    with_input_field_for @user, :description, collection: ['foo', 'bar'], disabled: true
+    assert_select 'select[disabled]'
+    assert_no_select 'option[disabled]'
+  end
+
+  test 'input_field collection allows individual disabled options' do
+    with_input_field_for @user, :description, collection: ['foo', 'bar'], disabled: 'bar'
+    assert_no_select 'select[disabled]'
+    assert_no_select 'option[disabled][value=foo]'
+    assert_select 'option[disabled][value=bar]'
+  end
 end

--- a/test/support/misc_helpers.rb
+++ b/test/support/misc_helpers.rb
@@ -255,6 +255,12 @@ module MiscHelpers
       f.input(attribute_name, options.merge(as: type))
     end
   end
+
+  def with_input_field_for(object, *args)
+    with_concat_form_for(object) do |f|
+      f.input_field(*args)
+    end
+  end
 end
 
 class CustomFormBuilder < SimpleForm::FormBuilder


### PR DESCRIPTION
Allows individual options to be disabled instead of just the whole
select.

Fixes #1365.