### PR TITLE
Allow custom error on forms without model

### DIFF
--- a/lib/simple_form/components/errors.rb
+++ b/lib/simple_form/components/errors.rb
@@ -11,7 +11,7 @@ module SimpleForm
       end
 
       def has_errors?
-        object && object.respond_to?(:errors) && errors.present?
+        object_with_errors? || object.nil? && has_custom_error?
       end
 
       def has_value?
@@ -32,6 +32,10 @@ module SimpleForm
 
       def full_error_text
         has_custom_error? ? options[:error] : full_errors.send(error_method)
+      end
+
+      def object_with_errors?
+        object && object.respond_to?(:errors) && errors.present?
       end
 
       def error_method

--- a/test/form_builder/error_test.rb
+++ b/test/form_builder/error_test.rb
@@ -224,6 +224,12 @@ class ErrorTest < ActionView::TestCase
     assert_no_select 'span.error'
   end
 
+  test 'input with custom error works when form does not use a model' do
+    with_form_for :user, :active, error: "Super User Active! cannot be blank"
+
+    assert_select 'span.error'
+  end
+
   test 'input with custom error works when using full_error component' do
     swap_wrapper :default, custom_wrapper_with_full_error do
       error_text = "Super User Name! cannot be blank"


### PR DESCRIPTION
This PR change the `has_errors?` method to allow custom errors on forms without a model:

### Before this PR

```
= simple_form_for :user, url: users_path do |f|
  = f.input :email, error: 'custom error'
```

##### Output

```
...
<div class="form-group email optional user_email">
  <label class="control-label email optional" for="user_email">Email</label>
  <input class="form-control string email optional" type="email" name="user[email]" id="user_email">
</div>
...
```

### After this PR

```
= simple_form_for :user, url: users_path do |f|
  = f.input :email, error: 'custom error'
```

##### Output

```
<div class="form-group email optional user_email has-error">
  <label class="control-label email optional" for="user_email">Email</label>
  <input class="form-control string email optional" aria-invalid="true" type="email" name="user[email]" id="user_email">
  <span class="help-block">custom error</span>
</div>
```