### PR TITLE
Improve date, time, and datetime Bootstrap layout

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -335,6 +335,16 @@ SimpleForm.setup do |config|
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
 
+  # custom select
+  config.wrappers :custom_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
   # custom multi select
   config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
     b.use :html5
@@ -434,6 +444,7 @@ SimpleForm.setup do |config|
   #   file:          :custom_file,
   #   radio_buttons: :custom_collection,
   #   range:         :custom_range,
+  #   select:        :custom_select,
   #   time:          :custom_multi_select
   # }
 end

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -45,6 +45,19 @@ SimpleForm.setup do |config|
   config.input_field_error_class = 'is-invalid'
   config.input_field_valid_class = 'is-valid'
 
+  # Configure layout of date input, time input, and datetime input.
+  SimpleForm::Inputs::DateTimeInput.default_options = {
+    date_separator: '<div class="mx-1"></div>',
+    time_separator: '<div class="mx-1">:</div>',
+    datetime_separator: '<div class="col-2 mw-100 flex-shrink-1 text-center">&mdash;</div>',
+    with_css_classes: {
+      year: "col-3 mw-100 flex-grow-1 flex-shrink-1",
+      month: "col-5 mw-100 flex-grow-1 flex-shrink-1",
+      day: "col-2 mw-100 flex-grow-1 flex-shrink-1",
+      hour: "col-2 mw-100 flex-grow-1 flex-shrink-1",
+      minute: "col-2 mw-100 flex-grow-1 flex-shrink-1",
+    },
+  }
 
   # vertical forms
   #
@@ -117,8 +130,8 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap flex-md-nowrap' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
@@ -218,8 +231,8 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'col-sm-3 control-label'
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
-        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap' do |bb|
+        bb.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
       end
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
       ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
@@ -350,8 +363,8 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.wrapper tag: 'div', class: 'd-flex flex-row align-items-center flex-wrap flex-md-nowrap' do |ba|
+      ba.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
     end
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }


### PR DESCRIPTION
The previous method of styling added margins around date, time, and datetime inputs which required extra (user-supplied) CSS to remove in order to have the inputs line up with their labels.  Additionally, the default sizing of the component select boxes (e.g. year, month, day) made the inputs illegible on mobile.

This patch preserves spacing between component select boxes while keeping inputs lined up with their labels (without requiring extra CSS). It also changes the relative sizing of the component select boxes to better reflect their content, and adds controlled wrapping on mobile to ensure legibility.

### Before (desktop)
<img src="https://user-images.githubusercontent.com/771968/40802649-dae96f38-64db-11e8-962e-31c71edab4ff.png" height="200" />

### After (desktop)
<img src="https://user-images.githubusercontent.com/771968/40802646-da301fa6-64db-11e8-8ac6-be9a9f446b6c.png" height="200" />

### Before (mobile)
<img src="https://user-images.githubusercontent.com/771968/40802650-db29f418-64db-11e8-8755-c4ae331e6a58.png" height="200" />

### After (mobile)
<img src="https://user-images.githubusercontent.com/771968/40802647-da5a69fa-64db-11e8-8c7d-a23b3c27c076.png" height="200" />
