### PR TITLE
remove error_notification_id from generator template

### DIFF
--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -87,9 +87,6 @@ SimpleForm.setup do |config|
   # CSS class to add for error notification helper.
   config.error_notification_class = 'error_notification'
 
-  # ID to add for error notification helper.
-  # config.error_notification_id = nil
-
   # Series of attempts to detect a default label method for collection.
   # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
 


### PR DESCRIPTION
config was removed in f67bdbb12255da21c4253bc492fda32337da664a