### PR TITLE
Allows config.wrapper_mappings to allow wrapper: false

### DIFF
--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -616,7 +616,7 @@ module SimpleForm
     # 1) It tries to find a wrapper for the current form
     # 2) If not, it tries to find a config
     def find_wrapper_mapping(input_type)
-      if options[:wrapper_mappings] && options[:wrapper_mappings][input_type]
+      if options[:wrapper_mappings] && !options[:wrapper_mappings][input_type].nil?
         options[:wrapper_mappings][input_type]
       else
         SimpleForm.wrapper_mappings && SimpleForm.wrapper_mappings[input_type]
@@ -624,8 +624,14 @@ module SimpleForm
     end
 
     def find_wrapper(input_type, options)
-      if name = options[:wrapper] || find_wrapper_mapping(input_type)
-        name.respond_to?(:render) ? name : SimpleForm.wrapper(name)
+      wrapper_or_name = options[:wrapper] || find_wrapper_mapping(input_type)
+
+      if wrapper_or_name.respond_to?(:render)
+        wrapper_or_name
+      elsif wrapper_or_name == false
+        SimpleForm::Wrappers::Root.new(wrapper.components, wrapper.options.merge(wrapper: false))
+      elsif wrapper_or_name
+        SimpleForm.wrapper(wrapper_or_name)
       else
         wrapper
       end

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -238,6 +238,18 @@ class WrapperTest < ActionView::TestCase
     end
   end
 
+  test 'uses wrapper for specified in config mapping when wrapper is false' do
+    swap_wrapper :string, false do
+      swap SimpleForm, wrapper_mappings: { string: false } do
+        # binding.pry
+        with_form_for @user, :name
+
+        assert_select 'form > label[for=user_name]'
+        assert_select 'form > input#user_name.string'
+      end
+    end
+  end
+
   test 'uses custom wrapper mapping per form basis' do
     swap_wrapper :another do
       with_concat_form_for @user, wrapper_mappings: { string: :another } do |f|

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -241,12 +241,21 @@ class WrapperTest < ActionView::TestCase
   test 'uses wrapper for specified in config mapping when wrapper is false' do
     swap_wrapper :string, false do
       swap SimpleForm, wrapper_mappings: { string: false } do
-        # binding.pry
         with_form_for @user, :name
-
         assert_select 'form > label[for=user_name]'
         assert_select 'form > input#user_name.string'
       end
+    end
+  end
+
+  test 'uses custom wrapper mapping per form basis when wrapper is false' do
+    swap_wrapper :string, false do
+      with_concat_form_for @user, wrapper_mappings: { string: false } do |f|
+        concat f.input :name
+      end
+
+      assert_select 'form > label[for=user_name]'
+      assert_select 'form > input#user_name.string'
     end
   end
 


### PR DESCRIPTION
Given a custom SimpleForm input `class MyCustomInput < SimpleForm::Inputs::Base; end`

It appears a `wrapper_mappings` can't be configured with the option of `wrapper: false`. 

Passing the option to `input`, or using `input_field` will work

```
<%= f.input :attribute, as: :my_custom, wrapper: false %>
<%= f.input_field :attribute %>
```

but setting `wrapper_mappings` to disable the wrapper, like this

```
# config/initializers/simple_form.rb
config.wrapper_mappings = {
  my_custom: false
}
```

will not work: wrapper will be still rendered. This behaviour feels unexpected and not consistent with `f.input`. 

This PR allows for this setting to be set. 

If behaviour described was intended for any reason, and PR is not to be accepted, or if there is something I can improve in the PR, please let me know. 

_Originated by this question at SO:_ https://stackoverflow.com/questions/51916852/how-to-configure-a-simpleform-input-to-default-to-no-wrapper/51917096#51917096 