### PR TITLE
Add test to make sure you can remove default classes in custom inputs

### DIFF
--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -109,6 +109,14 @@ class DiscoveryTest < ActionView::TestCase
     end
   end
 
+  test 'new inputs can override the default input_html_classes' do
+    discovery do
+      with_form_for @user, :avatar, as: :file
+      assert_select 'form input[type=file]#user_avatar.file.file-upload', false
+      assert_select 'form input[type=file]#user_avatar.file-upload'
+    end
+  end
+
   test 'inputs method without wrapper_options are deprecated' do
     discovery do
       assert_deprecated do

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -15,6 +15,7 @@ class DiscoveryTest < ActionView::TestCase
         Object.send :remove_const, :CustomizedInput
         Object.send :remove_const, :DeprecatedInput
         Object.send :remove_const, :CollectionSelectInput
+        Object.send :remove_const, :FileInput
         CustomInputs.send :remove_const, :CustomizedInput
         CustomInputs.send :remove_const, :PasswordInput
         CustomInputs.send :remove_const, :NumericInput

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -113,7 +113,7 @@ class DiscoveryTest < ActionView::TestCase
   test 'new inputs can override the default input_html_classes' do
     discovery do
       with_form_for @user, :avatar, as: :file
-      assert_select 'form input[type=file]#user_avatar.file.file-upload', false
+      assert_no_select 'form input[type=file]#user_avatar.file.file-upload'
       assert_select 'form input[type=file]#user_avatar.file-upload'
     end
   end

--- a/test/support/discovery_inputs.rb
+++ b/test/support/discovery_inputs.rb
@@ -39,7 +39,7 @@ end
 
 class FileInput < SimpleForm::Inputs::FileInput
   def input_html_classes
-    super.delete_if { |html_class| html_class == 'file' }
+    super.delete_if { |html_class| html_class == :file }
     super.push('file-upload')
   end
 end

--- a/test/support/discovery_inputs.rb
+++ b/test/support/discovery_inputs.rb
@@ -37,6 +37,13 @@ class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
   end
 end
 
+class FileInput < SimpleForm::Inputs::FileInput
+  def input_html_classes
+    super.delete_if { |html_class| html_class == 'file' }
+    super.push('file-upload')
+  end
+end
+
 module CustomInputs
   class CustomizedInput < SimpleForm::Inputs::StringInput
     def input_html_classes


### PR DESCRIPTION
A simple passing test to make sure you can remove classes from `input_html_classes` as well as add to them.

Creating this pull request to accompany an issue I created: #1602.