### PR TITLE
Memoize input_html_classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fix
 * Improve disabled option to input_field. [betelgeuse](https://github.com/betelgeuse)
+* Memoize `input_html_classes` in `SimpleForm::Inputs::Base`. [@RigoTheDev](https://github.com/RigoTheDev)
 
 ## 4.0.1
 

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -73,13 +73,13 @@ module SimpleForm
 
         @input_html_classes = @html_classes.dup
 
-        input_html_classes_memoized = input_html_classes
+        input_html_classes = self.input_html_classes
 
-        if SimpleForm.input_class && !input_html_classes_memoized.empty?
-          input_html_classes_memoized << SimpleForm.input_class
+        if SimpleForm.input_class && input_html_classes.any?
+          input_html_classes << SimpleForm.input_class
         end
 
-        @input_html_options = html_options_for(:input, input_html_classes_memoized).tap do |o|
+        @input_html_options = html_options_for(:input, input_html_classes).tap do |o|
           o[:readonly]  = true if has_readonly?
           o[:disabled]  = true if has_disabled?
           o[:autofocus] = true if has_autofocus?

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -72,11 +72,14 @@ module SimpleForm
         @html_classes = SimpleForm.additional_classes_for(:input) { additional_classes }
 
         @input_html_classes = @html_classes.dup
-        if SimpleForm.input_class && !input_html_classes.empty?
-          input_html_classes << SimpleForm.input_class
+
+        input_html_classes_memoized = input_html_classes
+
+        if SimpleForm.input_class && !input_html_classes_memoized.empty?
+          input_html_classes_memoized << SimpleForm.input_class
         end
 
-        @input_html_options = html_options_for(:input, input_html_classes).tap do |o|
+        @input_html_options = html_options_for(:input, input_html_classes_memoized).tap do |o|
           o[:readonly]  = true if has_readonly?
           o[:disabled]  = true if has_disabled?
           o[:autofocus] = true if has_autofocus?

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -115,7 +115,7 @@ class DiscoveryTest < ActionView::TestCase
         with_form_for @user, :active, as: :select
         assert_select 'form select#user_active.select' do
           # Make sure class list contains 'chosen' only once.
-          assert_select '[class=?]', /^(?!.*\bchosen\b.*\bchosen\b).*\bchosen\b.*$/
+          assert_select ":match('class', ?)", /^(?!.*\bchosen\b.*\bchosen\b).*\bchosen\b.*$/
         end
       end
     end

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -109,7 +109,7 @@ class DiscoveryTest < ActionView::TestCase
     end
   end
 
-  test 'giving extra class to input_html_classes adds it to element only once' do
+  test 'does not duplicate the html classes giving a extra class' do
     discovery do
       swap SimpleForm, input_class: 'custom-default-input-class' do
         with_form_for @user, :active, as: :select

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -109,6 +109,18 @@ class DiscoveryTest < ActionView::TestCase
     end
   end
 
+  test 'giving extra class to input_html_classes adds it to element only once' do
+    discovery do
+      swap SimpleForm, input_class: 'custom-default-input-class' do
+        with_form_for @user, :active, as: :select
+        assert_select 'form select#user_active.select' do
+          # Make sure class list contains 'chosen' only once.
+          assert_select '[class=?]', /^(?!.*\bchosen\b.*\bchosen\b).*\bchosen\b.*$/
+        end
+      end
+    end
+  end
+
   test 'inputs method without wrapper_options are deprecated' do
     discovery do
       assert_deprecated do

--- a/test/inputs/discovery_test.rb
+++ b/test/inputs/discovery_test.rb
@@ -121,7 +121,7 @@ class DiscoveryTest < ActionView::TestCase
       end
     end
   end
-  
+
   test 'new inputs can override the default input_html_classes' do
     discovery do
       with_form_for @user, :avatar, as: :file


### PR DESCRIPTION
Fixes: #1604. `input_html_classes` is a function therefore calling it multiple times will run the function multiple times.

This pull request stores the return value of `input_html_classes` in a variable so that it is called only once. That variable can then be used instead.