### PR TITLE
Create setting to be able to remove input_type classes from generated elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * Guess input type more carefully. [sringling](https://github.com/sringling)
 * Allow custom error on forms without model. [victorperez](https://github.com/victorperez)
+* Allow removing input_type classes from generated elements. [@RigoTheDev](https://github.com/RigoTheDev)
 
 ### Bug fix
 * Improve disabled option to input_field. [betelgeuse](https://github.com/betelgeuse)

--- a/lib/generators/simple_form/templates/config/initializers/simple_form.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form.rb
@@ -119,6 +119,10 @@ SimpleForm.setup do |config|
   # You can define which elements should obtain additional classes
   # config.generate_additional_classes_for = [:wrapper, :label, :input]
 
+  # You can define whether generated elements contain input type classes.
+  # Default is true.
+  # config.generate_input_type_class = true
+
   # Whether attributes are required by default (or not). Default is true.
   # config.required_by_default = true
 

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -112,6 +112,10 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   mattr_accessor :generate_additional_classes_for
   @@generate_additional_classes_for = %i[wrapper label input]
 
+  # You can define whether generated inputs contain input type classes
+  mattr_accessor :generate_input_type_class
+  @@generate_input_type_class = true
+
   # Whether attributes are required by default or not.
   mattr_accessor :required_by_default
   @@required_by_default = true

--- a/lib/simple_form.rb
+++ b/lib/simple_form.rb
@@ -112,7 +112,7 @@ See https://github.com/plataformatec/simple_form/pull/997 for more information.
   mattr_accessor :generate_additional_classes_for
   @@generate_additional_classes_for = %i[wrapper label input]
 
-  # You can define whether generated inputs contain input type classes
+  # You can define whether generated elements contain input type classes.
   mattr_accessor :generate_input_type_class
   @@generate_input_type_class = true
 

--- a/lib/simple_form/components/labels.rb
+++ b/lib/simple_form/components/labels.rb
@@ -49,7 +49,10 @@ module SimpleForm
 
       def label_html_options
         label_html_classes = SimpleForm.additional_classes_for(:label) {
-          [input_type, required_class, disabled_class, SimpleForm.label_class].compact
+          html_classes = [required_class, disabled_class, SimpleForm.label_class]
+          html_classes.unshift(input_type) if SimpleForm.generate_input_type_class
+
+          html_classes.compact
         }
 
         label_options = html_options_for(:label, label_html_classes)

--- a/lib/simple_form/inputs/base.rb
+++ b/lib/simple_form/inputs/base.rb
@@ -92,7 +92,10 @@ module SimpleForm
       end
 
       def additional_classes
-        @additional_classes ||= [input_type, required_class, readonly_class, disabled_class].compact
+        additional_classes = [required_class, readonly_class, disabled_class]
+        additional_classes.unshift(input_type) if SimpleForm.generate_input_type_class
+
+        @additional_classes ||= additional_classes.compact
       end
 
       def input_class

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -80,6 +80,22 @@ class FormBuilderTest < ActionView::TestCase
     end
   end
 
+  test 'builder allows removing input_type class for label' do
+    swap SimpleForm, generate_input_type_class: false do
+      with_form_for @user, :post_count
+      assert_no_select 'form label#user_post_count.required.integer'
+      assert_select 'form label[for=user_post_count].required'
+    end
+  end
+
+  test 'builder allows removing input_type class for wrapper' do
+    swap SimpleForm, generate_input_type_class: false do
+      with_form_for @user, :post_count
+      assert_no_select 'form div.user_post_count.required.integer'
+      assert_select 'form div.user_post_count.required'
+    end
+  end
+
   test 'builder allows to add additional classes only for wrapper' do
     swap SimpleForm, generate_additional_classes_for: [:wrapper] do
       with_form_for @user, :post_count

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -64,11 +64,19 @@ class FormBuilderTest < ActionView::TestCase
     end
   end
 
-  test 'builder allows to skip input_type class' do
+  test 'builder allows skipping additional classes for input' do
     swap SimpleForm, generate_additional_classes_for: %i[label wrapper] do
       with_form_for @user, :post_count
-      assert_no_select "form input#user_post_count.integer"
+      assert_no_select "form input#user_post_count.required.integer"
       assert_select "form input#user_post_count"
+    end
+  end
+
+  test 'builder allows removing input_type class for input' do
+    swap SimpleForm, generate_input_type_class: false do
+      with_form_for @user, :post_count
+      assert_no_select 'form input#user_post_count.required.integer'
+      assert_select 'form input#user_post_count.required'
     end
   end
 

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -16,14 +16,6 @@ class InputTest < ActionView::TestCase
     assert_select 'select.datetime'
   end
 
-  test 'input does not generate css class based on default input type when configured not to' do
-    swap SimpleForm, generate_input_type_class: false do
-      with_input_for @user, :name, :string
-      assert_select 'input.string#user_name', false
-      assert_select 'input#user_name'
-    end
-  end
-
   test 'string input generates autofocus attribute when autofocus option is true' do
     with_input_for @user, :name, :string, autofocus: true
     assert_select 'input.string[autofocus]'

--- a/test/inputs/general_test.rb
+++ b/test/inputs/general_test.rb
@@ -16,6 +16,14 @@ class InputTest < ActionView::TestCase
     assert_select 'select.datetime'
   end
 
+  test 'input does not generate css class based on default input type when configured not to' do
+    swap SimpleForm, generate_input_type_class: false do
+      with_input_for @user, :name, :string
+      assert_select 'input.string#user_name', false
+      assert_select 'input#user_name'
+    end
+  end
+
   test 'string input generates autofocus attribute when autofocus option is true' do
     with_input_for @user, :name, :string, autofocus: true
     assert_select 'input.string[autofocus]'


### PR DESCRIPTION
This configuration setting allows you to remove input_type classes from generated wrappers, labels, & inputs. All existing functionality stays the same so this change is non-breaking.

By default, all generated inputs look like this:

```html
<div class="field text optional item_description">
  <label class="text optional" for="item_description">Description</label>
  <textarea class="text optional" name="item[description]" id="item_description"></textarea>
</div>
```

By adding this configuration in `config/initializers/simple_form.rb`:
```ruby
  ...
  config.generate_input_type_class = false # Note that by default it's true.
  ...
```

...all generated inputs now look like this:
```html
<div class="field optional item_description">
  <label class="optional" for="item_description">Description</label>
  <textarea class="optional" name="item[description]" id="item_description"></textarea>
</div>
```

Also note that `optional/required` classes stay the same.