### PR TITLE
Add support to Money field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Enhancements
+- Set multiple attribute for grouped selects also. [@ollym)](https://github.com/ollym)
+- Add support to Money field .[@feliperenan](https://github.com/feliperenan)
+
 ## 4.1.0
 
 ### Enhancements

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -32,6 +32,7 @@ module SimpleForm
     map_type :country, :time_zone,                                 to: SimpleForm::Inputs::PriorityInput
     map_type :boolean,                                             to: SimpleForm::Inputs::BooleanInput
     map_type :hidden,                                              to: SimpleForm::Inputs::HiddenInput
+    map_type :money,                                               to: SimpleForm::Inputs::MoneyInput
 
     def self.discovery_cache
       @discovery_cache ||= {}

--- a/lib/simple_form/inputs.rb
+++ b/lib/simple_form/inputs.rb
@@ -21,5 +21,6 @@ module SimpleForm
     autoload :RangeInput
     autoload :StringInput
     autoload :TextInput
+    autoload :MoneyInput
   end
 end

--- a/lib/simple_form/inputs/money_input.rb
+++ b/lib/simple_form/inputs/money_input.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module SimpleForm
+  module Inputs
+    class MoneyInput < Base
+      enable :placeholder, :maxlength, :minlength
+
+      def input(wrapper_options = nil)
+        merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+        @builder.text_field(attribute_name, merged_input_options)
+      end
+    end
+  end
+end

--- a/test/inputs/money_input_test.rb
+++ b/test/inputs/money_input_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class MoneyTest < ActionView::TestCase
+  test 'input maps money field to string attribute' do
+    with_input_for @user, :amount, :money
+
+    assert_select "input.money[type=text][name='user[amount]']"
+  end
+end


### PR DESCRIPTION
Fix https://github.com/plataformatec/simple_form/issues/1579

Since Rails has support to `money` field, I'm adding to Simple Form render this input properly.