### PR TITLE
Support to label custom classes for inline checkboxes and radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Enhancements
+* Set multiple attribute for grouped selects also. [@ollym](https://github.com/ollym)
+* Removes or renames label classes. [Abduvakilov](https://github.com/Abduvakilov)
+* Support to label custom classes for inline collections. [@feliperenan](https://github.com/feliperenan)
+
 ## 4.1.0
 
 ### Enhancements
@@ -7,7 +12,6 @@
 * Allow custom error on forms without model. [@victorperez](https://github.com/victorperez)
 * Do not support Ruby < 2.3 anymore. [@gssbzn](https://github.com/gssbzn)
 * Add color input type. [@gssbzn](https://github.com/gssbzn)
-* Set multiple attribute for grouped selects also. [@ollym](https://github.com/ollym)
 
 ### Bug fix
 * Improve disabled option to input_field. [@betelgeuse](https://github.com/betelgeuse)

--- a/README.md
+++ b/README.md
@@ -545,6 +545,12 @@ form_for @user do |f|
 end
 ```
 
+To add a CSS class to the label item, you can use the `item_label_class` option:
+
+```ruby
+f.collection_check_boxes :role_ids, Role.all, :id, :name, item_label_class: 'my-custom-class' 
+```
+
 ## Available input types and defaults for each column type
 
 The following table shows the html element you will get for each attribute

--- a/lib/simple_form/tags.rb
+++ b/lib/simple_form/tags.rb
@@ -48,7 +48,9 @@ module SimpleForm
       private
 
       def render_component(builder)
-        builder.radio_button + builder.label(class: "collection_radio_buttons")
+        label_class = "#{@options[:item_label_class]} collection_radio_buttons".strip
+
+        builder.radio_button + builder.label(class: label_class)
       end
     end
 
@@ -62,7 +64,9 @@ module SimpleForm
       private
 
       def render_component(builder)
-        builder.check_box + builder.label(class: "collection_check_boxes")
+        label_class = "#{@options[:item_label_class]} collection_check_boxes".strip
+
+        builder.check_box + builder.label(class: label_class)
       end
     end
   end

--- a/test/inputs/collection_check_boxes_input_test.rb
+++ b/test/inputs/collection_check_boxes_input_test.rb
@@ -316,4 +316,12 @@ class CollectionCheckBoxesInputTest < ActionView::TestCase
       assert_select 'span.checkbox > label', '200'
     end
   end
+
+  test 'input check boxes with inline style support label custom classes' do
+    swap SimpleForm, boolean_style: :inline do
+      with_input_for @user, :gender, :check_boxes, collection: %i[male female], item_label_class: 'beautiful-label'
+
+      assert_select 'label.beautiful-label', count: 2
+    end
+  end
 end

--- a/test/inputs/collection_radio_buttons_input_test.rb
+++ b/test/inputs/collection_radio_buttons_input_test.rb
@@ -439,4 +439,12 @@ class CollectionRadioButtonsInputTest < ActionView::TestCase
       assert_select 'span.radio > label', '200'
     end
   end
+
+  test 'input check boxes with inline style support label custom classes' do
+    swap SimpleForm, boolean_style: :inline do
+      with_input_for @user, :gender, :radio_buttons, collection: %i[male female], item_label_class: 'beautiful-label'
+
+      assert_select 'label.beautiful-label', count: 2
+    end
+  end
 end


### PR DESCRIPTION
Fix https://github.com/plataformatec/simple_form/issues/1628 and related to https://github.com/plataformatec/simple_form/pull/1369

Simple Form already supports label custom classes for checkboxes / radio buttons when they have nested style. This commit allows this feature if they are inline as well.

cc @m5o 