### PR TITLE
refinements for bootstrap v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Set multiple attribute for grouped selects also. [@ollym](https://github.com/ollym)
 * Removes or renames label classes. [Abduvakilov](https://github.com/Abduvakilov)
 * Support to label custom classes for inline collections. [@feliperenan](https://github.com/feliperenan)
-* Update bootstrap generator template to match v4.1.3. [@m5o](https://github.com/m5o)
+* Update bootstrap generator template to match v4.3.x. [@m5o](https://github.com/m5o)
 
 ## 4.1.0
 

--- a/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
+++ b/lib/generators/simple_form/templates/config/initializers/simple_form_bootstrap.rb
@@ -403,7 +403,7 @@ SimpleForm.setup do |config|
   config.wrappers :floating_labels_select, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: 'custom-select custom-select-lg', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }


### PR DESCRIPTION
* minor refinements bootstrap `v4.3.1` with floating labels

:link: https://github.com/rafaelfranca/simple_form-bootstrap/pull/103