### PR TITLE
Allow "required" attribute in generated select elements of PriorityInput

### DIFF
--- a/lib/simple_form/inputs/priority_input.rb
+++ b/lib/simple_form/inputs/priority_input.rb
@@ -15,10 +15,6 @@ module SimpleForm
 
       protected
 
-      def has_required?
-        false
-      end
-
       def skip_include_blank?
         super || input_priority.present?
       end

--- a/test/inputs/priority_input_test.rb
+++ b/test/inputs/priority_input_test.rb
@@ -36,15 +36,15 @@ class PriorityInputTest < ActionView::TestCase
     assert_no_select 'select option[value=""]', /^$/
   end
 
-  test 'priority input does not generate invalid required html attribute' do
+  test 'priority input does generate select element with required html attribute' do
     with_input_for @user, :country, :country
     assert_select 'select.required'
-    assert_no_select 'select[required]'
+    assert_select 'select[required]'
   end
 
-  test 'priority input does not generate invalid aria-required html attribute' do
+  test 'priority input does generate select element with aria-required html attribute' do
     with_input_for @user, :country, :country
     assert_select 'select.required'
-    assert_no_select 'select[aria-required]'
+    assert_select 'select[aria-required]'
   end
 end


### PR DESCRIPTION
Don't overwrite `#has_required?` in `PriorityInput`, let that input inherit behavior.

Properly close #1355.
Properly close #866.
Continuation of #373 that closed #340.
Undoes some of, very old, outdated, #141.