### PR TITLE
Remove dead documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,6 @@ end
 </form>
 ```
 
-Produces:
-
-```html
-<input class="string required" id="user_name" maxlength="100"
-   name="user[name]" size="100" type="text" value="Carlos" />
-```
-
 To view the actual RDocs for this, check them out here - http://rubydoc.info/github/plataformatec/simple_form/master/SimpleForm/FormBuilder:input_field
 
 ### Collections


### PR DESCRIPTION
Hello,

The commit https://github.com/plataformatec/simple_form/commit/d1ff0b11a48172dc85df409d0d270732ada011b9 introduced this text, and the https://github.com/plataformatec/simple_form/commit/caca9457266fdbc8243c2b9ba8de37e64409c58a forgot to remove some of the text when it was updated.

This dead text has been there a while :sweat_smile: 