### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/simple_form.gemspec
+++ b/simple_form.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.test_files   -= Dir["test/support/country_select/**/*"]
   s.require_paths = ["lib"]
 
-  s.rubyforge_project = "simple_form"
-
   s.add_dependency('activemodel', '>= 5.0')
   s.add_dependency('actionpack', '>= 5.0')
 end


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.