### PR TITLE
Fix tests on Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.6.3
   - ruby-head
   - jruby-9.1.17.0
-  - jruby-9.2.0.0
+  - jruby-9.2.7.0
 gemfile:
   - gemfiles/Gemfile.rails-5-0-stable
   - gemfiles/Gemfile.rails-5-1-stable
@@ -26,8 +26,10 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0
       gemfile: Gemfile
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.7.0
       gemfile: Gemfile
+before_install:
+  - gem update --system
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
-  - ruby-head
   - jruby-9.1.17.0
   - jruby-9.2.7.0
 gemfile:
@@ -23,7 +22,6 @@ matrix:
     - rvm: jruby-9.1.17.0
       gemfile: Gemfile
   allow_failures:
-    - rvm: ruby-head
     - rvm: jruby-9.1.17.0
       gemfile: Gemfile
     - rvm: jruby-9.2.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.4.6
       gemfile: Gemfile
+    - rvm: jruby-9.1.17.0
+      gemfile: Gemfile
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-9.1.17.0

--- a/test/action_view_extensions/builder_test.rb
+++ b/test/action_view_extensions/builder_test.rb
@@ -45,8 +45,17 @@ class BuilderTest < ActionView::TestCase
 
   test "collection radio sanitizes collection values for labels correctly" do
     with_collection_radio_buttons @user, :name, ['$0.99', '$1.99'], :to_s, :to_s
-    assert_select 'label.collection_radio_buttons[for=user_name_099]', '$0.99'
-    assert_select 'label.collection_radio_buttons[for=user_name_199]', '$1.99'
+
+    # Rails 6 changed the way it sanitizes the values
+    # https://github.com/rails/rails/blob/6-0-stable/actionview/lib/action_view/helpers/tags/base.rb#L141
+    # https://github.com/rails/rails/blob/5-2-stable/actionview/lib/action_view/helpers/tags/base.rb#L141
+    if ActionView::VERSION::MAJOR == 5
+      assert_select 'label.collection_radio_buttons[for=user_name_099]', '$0.99'
+      assert_select 'label.collection_radio_buttons[for=user_name_199]', '$1.99'
+    else
+      assert_select 'label.collection_radio_buttons[for=user_name_0_99]', '$0.99'
+      assert_select 'label.collection_radio_buttons[for=user_name_1_99]', '$1.99'
+    end
   end
 
   test "collection radio checks the correct value to local variables" do
@@ -292,8 +301,17 @@ class BuilderTest < ActionView::TestCase
 
   test "collection check box sanitizes collection values for labels correctly" do
     with_collection_check_boxes @user, :name, ['$0.99', '$1.99'], :to_s, :to_s
-    assert_select 'label.collection_check_boxes[for=user_name_099]', '$0.99'
-    assert_select 'label.collection_check_boxes[for=user_name_199]', '$1.99'
+
+    # Rails 6 changed the way it sanitizes the values
+    # https://github.com/rails/rails/blob/6-0-stable/actionview/lib/action_view/helpers/tags/base.rb#L141
+    # https://github.com/rails/rails/blob/5-2-stable/actionview/lib/action_view/helpers/tags/base.rb#L141
+    if ActionView::VERSION::MAJOR == 5
+      assert_select 'label.collection_check_boxes[for=user_name_099]', '$0.99'
+      assert_select 'label.collection_check_boxes[for=user_name_199]', '$1.99'
+    else
+      assert_select 'label.collection_check_boxes[for=user_name_0_99]', '$0.99'
+      assert_select 'label.collection_check_boxes[for=user_name_1_99]', '$1.99'
+    end
   end
 
   test "collection check box checks the correct value to local variables" do

--- a/test/form_builder/wrapper_test.rb
+++ b/test/form_builder/wrapper_test.rb
@@ -161,7 +161,7 @@ class WrapperTest < ActionView::TestCase
   test 'custom wrappers can have full error message on attributes' do
     swap_wrapper :default, custom_wrapper_with_full_error do
       with_form_for @user, :name
-      assert_select 'span.error', "Name cannot be blank"
+      assert_select 'span.error', "Super User Name! cannot be blank"
     end
   end
 

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -204,7 +204,7 @@ class User
 
   def self.human_attribute_name(attribute, options = {})
     case attribute
-      when 'name'
+      when 'name', :name
         'Super User Name!'
       when 'description'
         'User Description!'


### PR DESCRIPTION
After we changed the default build to run on Rails 6 (https://github.com/plataformatec/simple_form/commit/fc25ab40a28ad477e1ac0e45ddcf7ad2b64891f3) the tests started failing. This pull request fixes them.

See the commit messages for more details of why each change was done.