### PR TITLE
Replace `_url` with `remote_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Bug fix
+* Replace `_url` with `remote_url` when trying to guess file inputs [@tegon](https://github.com/tegon). This has the side-effect of changing carrierwave's support from `0.2.1` to `0.2.2`.
+
 ## 5.0.0
 
 ### Enhancements

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -580,7 +580,7 @@ module SimpleForm
     #
     # Note: This does not support multiple file upload inputs, as this is very application-specific.
     #
-    # The order here was choosen based on the popularity of Gems:
+    # The order here was chosen based on the popularity of Gems:
     #
     # - `#{attribute_name}_attachment` - ActiveStorage >= `5.2` and Refile >= `0.2.0` <= `0.4.0`
     # - `remote_#{attribute_name}_url` - Refile >= `0.3.0` and CarrierWave >= `0.2.2`

--- a/lib/simple_form/form_builder.rb
+++ b/lib/simple_form/form_builder.rb
@@ -580,18 +580,17 @@ module SimpleForm
     #
     # Note: This does not support multiple file upload inputs, as this is very application-specific.
     #
-    # The order here was choosen based on the popularity of Gems and for commodity - e.g. the method
-    # with the suffix `_url` is present in three Gems, so it's checked with priority:
+    # The order here was choosen based on the popularity of Gems:
     #
     # - `#{attribute_name}_attachment` - ActiveStorage >= `5.2` and Refile >= `0.2.0` <= `0.4.0`
-    # - `#{attribute_name}_url` - Shrine >= `0.9.0`, Refile >= `0.6.0` and CarrierWave >= `0.2.1`
+    # - `remote_#{attribute_name}_url` - Refile >= `0.3.0` and CarrierWave >= `0.2.2`
     # - `#{attribute_name}_attacher` - Refile >= `0.4.0` and Shrine >= `0.9.0`
     # - `#{attribute_name}_file_name` - Paperclip ~> `2.0` (added for backwards compatibility)
     #
     # Returns a Boolean.
     def file_method?(attribute_name)
       @object.respond_to?("#{attribute_name}_attachment") ||
-        @object.respond_to?("#{attribute_name}_url") ||
+        @object.respond_to?("remote_#{attribute_name}_url") ||
         @object.respond_to?("#{attribute_name}_attacher") ||
         @object.respond_to?("#{attribute_name}_file_name")
     end

--- a/test/form_builder/general_test.rb
+++ b/test/form_builder/general_test.rb
@@ -244,7 +244,7 @@ class FormBuilderTest < ActionView::TestCase
     assert_select 'form input#user_with_attachment_avatar.file'
   end
 
-  test 'builder generates file input for Shrine >= 0.9.0, Refile >= 0.6.0 and CarrierWave >= 0.2.1' do
+  test 'builder generates file input for Refile >= 0.3.0 and CarrierWave >= 0.2.2' do
     with_form_for UserWithAttachment.build, :cover
     assert_select 'form input#user_with_attachment_cover.file'
   end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -339,7 +339,7 @@ class UserWithAttachment < User
     OpenStruct.new
   end
 
-  def cover_url
+  def remote_cover_url
     "/uploads/cover.png"
   end
 


### PR DESCRIPTION
As reported in https://github.com/plataformatec/simple_form/issues/1671, the method with suffix `_url` is likely to cause false positives. By using the alternative `remote_url` we might be able to make wrong assumptions, although they're still possible.

Fixes https://github.com/plataformatec/simple_form/issues/1671