### PR TITLE
Add color field type to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ Mapping         | Generated HTML Element               | Database Column Type
 `password`      | `input[type=password]`               | `string` with `name =~ /password/`
 `search`        | `input[type=search]`                 | -
 `uuid`          | `input[type=text]`                   | `uuid`
+`color`         | `input[type=color]`                  | `string`
 `text`          | `textarea`                           | `text`
 `hstore`        | `textarea`                           | `hstore`
 `json`          | `textarea`                           | `json`


### PR DESCRIPTION
Since it was released with the version 5, and it was discussed on the PR #1613 but never done, I thought I'd go ahead.


