### PR TITLE
Fix 'aria-required' field generated by prompt

### DIFF
--- a/lib/simple_form/inputs/collection_input.rb
+++ b/lib/simple_form/inputs/collection_input.rb
@@ -41,7 +41,7 @@ module SimpleForm
       end
 
       def has_required?
-        super && (input_options[:include_blank] || input_options[:prompt] || multiple?)
+        super && (input_options[:include_blank] || input_options[:prompt].present? || multiple?)
       end
 
       # Check if :include_blank must be included by default.

--- a/test/inputs/collection_select_input_test.rb
+++ b/test/inputs/collection_select_input_test.rb
@@ -284,6 +284,12 @@ class CollectionSelectInputTest < ActionView::TestCase
     assert_select 'select[required]'
   end
 
+  test "collection input generated aria-label should contain 'true'" do
+    with_input_for @user, :age, :select, collection: 18..30, prompt: "Please select foo"
+    assert_select 'select.required'
+    assert_select 'select[aria-required=true]'
+  end
+
   test 'collection input with select type does not generate required html attribute without blank option' do
     with_input_for @user, :name, :select, include_blank: false, collection: %w[Jose Carlos]
     assert_select 'select.required'


### PR DESCRIPTION
## Issue: #1675

## What's the problem?
When the prompt was set, example: `- please select an option -`, the value generated for the `aria-required` field value was the same as the prompt.

## What is the expected scenario?
The value of aria-required should be always a boolean.

### Screenshot

Before:
![image](https://user-images.githubusercontent.com/20001259/67149572-1cd6fd80-f283-11e9-9e14-fe5d264e186f.png)

After:
![image](https://user-images.githubusercontent.com/20001259/67149545-c9fd4600-f282-11e9-81b8-91be93e045a4.png)

