### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
-  - jruby-9.1.17.0
   - jruby-9.2.7.0
 gemfile:
   - gemfiles/Gemfile.rails-5-0-stable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,3 @@ DEPENDENCIES
   rubinius-developer_tools
   rubysl (~> 2.0)
   simple_form!
-
-BUNDLED WITH
-   1.17.3


### PR DESCRIPTION
This commit is supposed to fix the following error on Travis:

```
4: from /home/travis/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `<main>'
  3: from /home/travis/.rvm/gems/ruby-2.6.3/bin/ruby_executable_hooks:24:in `eval'
  2: from /home/travis/.rvm/rubies/ruby-2.6.3/bin/bundle:23:in `<main>'
  1: from /home/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:294:in `activate_bin_path'
/home/travis/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems.rb:275:in `find_spec_for_exe':
  Could not find 'bundler' (1.17.3) required by your /home/travis/build/plataformatec/simple_form/Gemfile.lock.
    (Gem::GemNotFoundException)
```

Ref: https://github.com/bundler/bundler/issues/6882#issuecomment-469858087

Also, the CI can no longer build for jruby 9.1.17.0 due this error:

```
NoMethodError: undefined method `[]' for nil:NilClass
  /home/travis/.rvm/gems/jruby-9.1.17.0/gems/bundler-2.1.2/lib/bundler/source/git/git_proxy.rb:90:in `version'
  /home/travis/.rvm/gems/jruby-9.1.17.0/gems/bundler-2.1.2/lib/bundler/source/git/git_proxy.rb:147:in `block in copy_to'
  org/jruby/RubyDir.java:323:in `chdir'
  /home/travis/.rvm/gems/jruby-9.1.17.0/gems/bundler-2.1.2/lib/bundler/shared_helpers.rb:52:in `block in chdir'
  /home/travis/.rvm/rubies/jruby-9.1.17.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
```

I'm not sure what to do to fix that, maybe we could remove this from our build and keep only the last version of jruby?

That's what this commit does 🙈.